### PR TITLE
Layer load callback

### DIFF
--- a/example/main.jsx
+++ b/example/main.jsx
@@ -38,6 +38,7 @@ render(
         zoomTo
         selectable
         url="https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Building_Montreal/SceneServer"
+        onLoad={({ id }) => console.log(id)}
       />
       <DistanceMeasurementTool
         onChange={e => console.log(e)}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -61,6 +61,7 @@ const layerSettingsProps = {
   legendEnabled: PropTypes.bool,
   title: PropTypes.string,
   maskingGeometry: PropTypes.object,
+  onLoad: PropTypes.func,
 };
 
 
@@ -229,6 +230,7 @@ class Layer extends Component {
     // Add layer to map
     view.map.add(layer);
     const layerView = await view.whenLayerView(layer);
+    this.props.onLoad({ id: layerSettings.id });
 
     // After every await, need to check if component is still mounted
     if (!this.componentIsMounted) {
@@ -331,6 +333,7 @@ Layer.defaultProps = {
   legendEnabled: true,
   title: null,
   maskingGeometry: null,
+  onLoad: () => null,
 };
 
 Layer.Graphic = Graphic;


### PR DESCRIPTION
Adds a callback to the layer that gets called when the layer has been loaded.

* Should we keep this consistent with the JS API and call it `when` or `whenLayerView` (please no)?