### PR TITLE
Bugfix/fix drawing tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -31,7 +31,6 @@ class UI extends Component {
   }
 
   updatePadding() {
-    console.log(this.props.padding);
     this.props.view.ui.padding = this.props.padding;
   }
 


### PR DESCRIPTION
Should fix the drawing tool when dynamically passing geometry after initialization.

I know that this is an ugly hack (using `geometry.reset`) but I don't know any better way of detecting when the geometry has been modified from outside and not from the Sketchtool.