### PR TITLE
Bugfix/performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -74,6 +74,8 @@ class SceneView extends Component {
   }
 
   async componentWillUpdate(nextProps) {
+    console.log('react-sceneview: SceneView component prop change');
+
     if (this.props.environment !== nextProps.environment) {
       const environment = this.parseEnvironment(nextProps.environment);
       Object.keys(environment).forEach(key => this.state.view.environment[key] = {
@@ -226,7 +228,7 @@ class SceneView extends Component {
         style={{ width: '100%', height: '100%' }}
         ref={(ref) => { this.componentRef = ref; }}
       >
-        {this.state.view &&
+        {this.state.view && this.props.children &&
           React.Children.map(this.props.children,
             child => child && React.cloneElement(child, {
               ...this.state,
@@ -284,7 +286,7 @@ SceneView.propTypes = {
 
 
 SceneView.defaultProps = {
-  children: [],
+  children: null,
   environment: null,
   highlightOptions: null,
   qualityProfile: 'medium',

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -74,8 +74,6 @@ class SceneView extends Component {
   }
 
   async componentWillUpdate(nextProps) {
-    console.log('react-sceneview: SceneView component prop change');
-
     if (this.props.environment !== nextProps.environment) {
       const environment = this.parseEnvironment(nextProps.environment);
       Object.keys(environment).forEach(key => this.state.view.environment[key] = {

--- a/src/scene/index.jsx
+++ b/src/scene/index.jsx
@@ -82,8 +82,6 @@ class Scene extends Component {
 
 
   render() {
-    console.log('react-sceneview: Scene component render');
-
     return this.state.webscene && this.props.view && (
       <div id="scene">
         {this.renderWrappedChildren(this.props.children)}

--- a/src/scene/index.jsx
+++ b/src/scene/index.jsx
@@ -57,6 +57,8 @@ class Scene extends Component {
 
 
   renderWrappedChildren(children) {
+    if (!children) return null;
+
     return React.Children.map(children, (child) => {
       // This is support for non-node elements (eg. pure text), they have no props
       if (!child || !child.props) {
@@ -80,6 +82,8 @@ class Scene extends Component {
 
 
   render() {
+    console.log('react-sceneview: Scene component render');
+
     return this.state.webscene && this.props.view && (
       <div id="scene">
         {this.renderWrappedChildren(this.props.children)}
@@ -101,7 +105,7 @@ Scene.propTypes = {
 };
 
 Scene.defaultProps = {
-  children: [],
+  children: null,
   portalItem: null,
   basemap: 'gray-vector',
   ground: 'world-elevation',

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -136,6 +136,13 @@ class Layer extends Component {
 
   async componentDidUpdate(prevProps) {
     if (!this.state.layer) return;
+    const changedPropKeys = Object.keys(prevProps)
+      .filter(key => prevProps[key] !== this.props[key]);
+
+    if (changedPropKeys.length === 0) return;
+
+    console.log(`react-sceneview: Layer ${this.state.layer.id} prop change`);
+    console.log(changedPropKeys);
 
     // refresh layer
     if (this.props.refresh !== prevProps.refresh) {
@@ -277,7 +284,7 @@ class Layer extends Component {
   render() {
     return this.state.layer && (
       <div>
-        {React.Children.map(this.props.children, child =>
+        {this.props.children && React.Children.map(this.props.children, child =>
           child && React.cloneElement(child, { layer: this.state.layer }))}
       </div>
     );
@@ -306,7 +313,7 @@ Layer.propTypes = {
 
 
 Layer.defaultProps = {
-  children: [],
+  children: null,
   url: null,
   portalItem: null,
   visible: true,

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -136,13 +136,7 @@ class Layer extends Component {
 
   async componentDidUpdate(prevProps) {
     if (!this.state.layer) return;
-    const changedPropKeys = Object.keys(prevProps)
-      .filter(key => prevProps[key] !== this.props[key]);
-
-    if (changedPropKeys.length === 0) return;
-
-    console.log(`react-sceneview: Layer ${this.state.layer.id} prop change`);
-    console.log(changedPropKeys);
+    if (!Object.keys(prevProps).find(key => prevProps[key] !== this.props[key])) return;
 
     // refresh layer
     if (this.props.refresh !== prevProps.refresh) {


### PR DESCRIPTION
`defaultProps.children: []` was causing a new array to be created in each render loop. `defaultProps.children: null` is better.