### PR TITLE
add style property to leayers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -218,6 +218,7 @@ Layer.defaultProps = {
   maskingGeometry: null,
   popupEnabled: false,
   popupTemplate: null,
+  style: null,
   onLoad: () => null,
 };
 

--- a/src/scene/layer/layer-settings-props.js
+++ b/src/scene/layer/layer-settings-props.js
@@ -42,4 +42,5 @@ export default {
   popupEnabled: PropTypes.bool,
   popupTemplate: PropTypes.object,
   onLoad: PropTypes.func,
+  style: PropTypes.object,
 };


### PR DESCRIPTION
Add the style property to layers required for vector tile layers, which do not load the style from a URL.

See: https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-VectorTileLayer.html