### PR TITLE
fix timing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -70,6 +70,8 @@ class SceneView extends Component {
   }
 
   async UNSAFE_componentWillUpdate(nextProps) { // eslint-disable-line camelcase
+    if (!this.state.view) return;
+
     if (this.props.environment !== nextProps.environment) {
       const environment = this.parseEnvironment(nextProps.environment);
       Object.keys(environment).forEach(key => this.state.view.environment[key] = {
@@ -210,6 +212,8 @@ class SceneView extends Component {
     const view = await loadEsriSceneView(this.componentRef, this.props.id, viewSettings);
 
     if (this.props.highlightOptions) view.highlightOptions = this.props.highlightOptions;
+    if (this.props.environment) view.highlightOptions = this.props.environment;
+    if (this.props.padding) view.highlightOptions = this.props.padding;
 
     this.setState({ view });
     if (this.props.onLoad) this.props.onLoad(view);


### PR DESCRIPTION
This fixes a bug where errors were thrown if the `environment` or `padding` props were changed before the sceneview has finished loading.