### PR TITLE
Feature/webscene loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ import { SceneView, Scene } from 'react-sceneview';
 ```jsx
 import React from 'react';
 import { render } from 'react-dom';
-import { SceneView, Scene } from 'react-sceneview';
+import { SceneView, Scene, Webscene } from 'react-sceneview';
 
 render(
   <SceneView id="sceneview">
-    <Scene portalItem={{ id: '34859cee6739438d93262a5aa91bf834' }} />
+    <Scene>
+      <Webscene  portalItem={{ id: '34859cee6739438d93262a5aa91bf834' }} />
+    </Scene>
   </SceneView>,
   document.getElementById('root'),
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
+    "react": ">=16.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -36,8 +35,7 @@
     "eslint-plugin-react": "^7.14.3",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
+    "react": ">=16.9.0",
     "react-test-renderer": "^15.6.2",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.1.75",
+  "version": "0.2.0",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -56,7 +56,6 @@ class SceneView extends Component {
     this.state = {
       view: (window.sceneViews && window.sceneViews[this.props.id] &&
         window.sceneViews[this.props.id].view) || null,
-      // selectionQuery: null,
     };
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -56,7 +56,7 @@ class SceneView extends Component {
     this.state = {
       view: (window.sceneViews && window.sceneViews[this.props.id] &&
         window.sceneViews[this.props.id].view) || null,
-      selectionQuery: null,
+      // selectionQuery: null,
     };
   }
 

--- a/src/scene/index.jsx
+++ b/src/scene/index.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
 import Layer, { Graphic } from './layer';
-// import Webscene from './webscene';
+import Webscene from './webscene';
 import Ground from './ground';
 import CustomBasemap from './custom-basemap';
 import CustomElevationLayer from './custom-elevation-layer';
@@ -70,13 +70,10 @@ class Scene extends Component {
         return React.cloneElement(child, {
           children: this.renderWrappedChildren(child.props.children),
           view: this.props.view,
-          // selectionQuery,
         });
       }
 
-      return React.cloneElement(child, { view: this.props.view,
-        // selectionQuery,
-      });
+      return React.cloneElement(child, { view: this.props.view });
     });
   }
 
@@ -84,7 +81,6 @@ class Scene extends Component {
     const {
       children,
       view,
-      // selectionQuery,
     } = this.props;
 
     return view && this.state.mapLoaded && (
@@ -103,7 +99,6 @@ Scene.propTypes = {
   ground: PropTypes.string,
   initialViewProperties: PropTypes.object,
   view: PropTypes.object,
-  // selectionQuery: PropTypes.object,
   onLoad: PropTypes.func,
 };
 
@@ -113,14 +108,14 @@ Scene.defaultProps = {
   ground: 'world-elevation',
   initialViewProperties: null,
   view: null,
-  // selectionQuery: null,
   onLoad: null,
 };
 
 Scene.Layer = Layer;
+Scene.Webscene = Webscene;
 Scene.CustomBasemap = CustomBasemap;
 Scene.CustomElevationLayer = CustomElevationLayer;
 
-export { Scene, Layer, Ground, Graphic, CustomBasemap, CustomElevationLayer };
+export { Scene, Layer, Webscene, Ground, Graphic, CustomBasemap, CustomElevationLayer };
 
 export default Scene;

--- a/src/scene/index.jsx
+++ b/src/scene/index.jsx
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
 import Layer, { Graphic } from './layer';
+// import Webscene from './webscene';
 import Ground from './ground';
 import CustomBasemap from './custom-basemap';
 import CustomElevationLayer from './custom-elevation-layer';
@@ -28,36 +29,33 @@ import SelectionLayer from './selection-layer';
 class Scene extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      webscene: null,
-    };
-
-    this.loadWebscene();
+    this.state = { mapLoaded: false };
   }
 
-  async loadWebscene() {
-    if (!this.props.view.map) {
-      const [WebScene] = await esriLoader.loadModules(['esri/WebScene']);
-
-      const webscene = new WebScene({
-        portalItem: this.props.portalItem,
-        basemap: this.props.basemap,
-        ground: this.props.ground,
-        initialViewProperties: this.props.initialViewProperties,
-      });
-
-      await webscene.load();
-
-      this.props.view.map = webscene;
-    }
-
-    await this.props.view.when();
-
-    this.setState({ webscene: this.props.view.map });
-
-    if (this.props.onLoad) this.props.onLoad(this.props.view.map);
+  componentDidMount() {
+    this.loadMap();
   }
 
+  async loadMap() {
+    const {
+      basemap,
+      ground,
+      initialViewProperties,
+      view,
+      onLoad,
+    } = this.props;
+
+    const [WebScene] = await esriLoader.loadModules(['esri/WebScene']);
+    const newMap = new WebScene({ basemap, ground, initialViewProperties });
+    await newMap.load();
+
+    view.map = newMap;
+    await view.when();
+
+    this.setState({ mapLoaded: true });
+
+    if (this.props.onLoad) onLoad(view.map);
+  }
 
   renderWrappedChildren(children) {
     if (!children) return null;
@@ -72,23 +70,27 @@ class Scene extends Component {
         return React.cloneElement(child, {
           children: this.renderWrappedChildren(child.props.children),
           view: this.props.view,
-          selectionQuery: this.props.selectionQuery,
+          // selectionQuery,
         });
       }
 
-      return React.cloneElement(child, {
-        view: this.props.view,
-        selectionQuery: this.props.selectionQuery,
+      return React.cloneElement(child, { view: this.props.view,
+        // selectionQuery,
       });
     });
   }
 
-
   render() {
-    return this.state.webscene && this.props.view && (
+    const {
+      children,
+      view,
+      // selectionQuery,
+    } = this.props;
+
+    return view && this.state.mapLoaded && (
       <div id="scene">
-        {this.renderWrappedChildren(this.props.children)}
-        <SelectionLayer id="selection-shape" view={this.props.view} />
+        {this.renderWrappedChildren(children)}
+        <SelectionLayer id="selection-shape" view={view} />
       </div>
     );
   }
@@ -97,23 +99,21 @@ class Scene extends Component {
 
 Scene.propTypes = {
   children: PropTypes.node,
-  portalItem: PropTypes.object,
   basemap: PropTypes.string,
   ground: PropTypes.string,
   initialViewProperties: PropTypes.object,
   view: PropTypes.object,
-  selectionQuery: PropTypes.object,
+  // selectionQuery: PropTypes.object,
   onLoad: PropTypes.func,
 };
 
 Scene.defaultProps = {
   children: null,
-  portalItem: null,
   basemap: 'gray-vector',
   ground: 'world-elevation',
   initialViewProperties: null,
   view: null,
-  selectionQuery: null,
+  // selectionQuery: null,
   onLoad: null,
 };
 

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -1,0 +1,110 @@
+/* Copyright 2019 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import esriLoader from 'esri-loader';
+
+
+class Webscene extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      layers: [],
+    };
+  }
+
+
+  componentDidMount() {
+    this.componentIsMounted = true;
+    this.loadWebscene();
+  }
+
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible !== prevProps.visible) {
+      this.state.layers.forEach(layer => layer.visible = this.props.visible);
+    }
+  }
+
+
+  componentWillUnmount() {
+    this.componentIsMounted = false;
+    if (!this.props.view || !this.props.view.map) return;
+    this.props.view.map.removeMany(this.state.layers);
+  }
+
+
+  async loadWebscene() {
+    if (!this.props.view || !this.props.view.map) return;
+
+    const [EsriWebScene, EsriLayer] = await esriLoader.loadModules([
+      'esri/WebScene',
+      'esri/layers/Layer',
+    ]);
+    if (!this.componentIsMounted) return;
+
+    const layers = [];
+
+    try {
+      const webscene = new EsriWebScene({ portalItem: this.props.portalItem });
+      await webscene.load();
+
+      layers.push(...webscene.layers.items);
+    } catch (err) {
+      // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
+      try {
+        const layer = await EsriLayer.fromPortalItem({ portalItem: this.props.portalItem });
+        layers.push(layer);
+      } catch (e) {
+        // give up
+      }
+    }
+    layers.forEach(layer => layer.visible = this.props.visible);
+
+    if (!this.componentIsMounted) return;
+
+    this.setState({ layers });
+    this.props.view.map.layers.addMany(layers);
+
+    await Promise.all(layers.map(layer => this.props.view.whenLayerView(layer)));
+    layers.forEach(layer => layer.visible = this.props.visible);
+
+    if (this.props.onLoad) this.props.onLoad(this.state.layers);
+  }
+
+  render() {
+    return <div />;
+  }
+}
+
+
+Webscene.propTypes = {
+  portalItem: PropTypes.object.isRequired,
+  view: PropTypes.object,
+  visible: PropTypes.bool,
+  onLoad: PropTypes.func,
+};
+
+
+Webscene.defaultProps = {
+  view: null,
+  visible: true,
+  onLoad: null,
+};
+
+
+export default Webscene;

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -35,16 +35,32 @@ class Webscene extends Component {
 
 
   componentDidUpdate(prevProps) {
-    if (this.props.visible !== prevProps.visible) {
-      this.state.layers.forEach(layer => layer.visible = this.props.visible);
-    }
+    this.update(prevProps);
   }
 
 
   componentWillUnmount() {
-    this.componentIsMounted = false;
     if (!this.props.view || !this.props.view.map) return;
+    this.componentIsMounted = false;
     this.props.view.map.removeMany(this.state.layers);
+  }
+
+
+  update(prevProps = {}) {
+    if (!this.props.view || !this.props.view.map) return;
+
+    if (prevProps.visible !== this.props.visible) {
+      this.state.layers.forEach(layer => layer.visible = this.props.visible);
+    }
+
+    if (prevProps.layerSettings !== this.props.layerSettings) {
+      Object.keys(this.props.layerSettings).forEach(layerId => {
+        const layer = this.props.view.map.layers.items.find(l => l.id === layerId);
+        const settings = this.props.layerSettings[layerId];
+
+        Object.keys(settings).forEach(field => layer[field] = settings[field]);
+      });
+    }
   }
 
 
@@ -81,7 +97,7 @@ class Webscene extends Component {
     this.props.view.map.layers.addMany(layers);
 
     await Promise.all(layers.map(layer => this.props.view.whenLayerView(layer)));
-    layers.forEach(layer => layer.visible = this.props.visible);
+    this.update();
 
     if (this.props.onLoad) this.props.onLoad(this.state.layers);
   }
@@ -97,6 +113,7 @@ Webscene.propTypes = {
   view: PropTypes.object,
   visible: PropTypes.bool,
   onLoad: PropTypes.func,
+  layerSettings: PropTypes.object,
 };
 
 
@@ -104,6 +121,7 @@ Webscene.defaultProps = {
   view: null,
   visible: true,
   onLoad: null,
+  layerSettings: {},
 };
 
 

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -55,8 +55,9 @@ class Webscene extends Component {
 
     if (prevProps.layerSettings !== this.props.layerSettings) {
       Object.keys(this.props.layerSettings).forEach(layerId => {
-        const layer = this.props.view.map.layers.items.find(l => l.id === layerId);
         const settings = this.props.layerSettings[layerId];
+        const layer = this.props.view.map.layers.items.find(l => l.id === layerId);
+        if (!layer) return;
 
         Object.keys(settings).forEach(field => layer[field] = settings[field]);
       });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -12,4 +12,13 @@ module.exports = merge(common, {
     library: 'react-sceneview',
     libraryTarget: 'umd',
   },
+  externals: {
+    react: {
+      root: 'React',
+      commonjs2: 'react',
+      commonjs: 'react',
+      amd: 'react',
+      umd: 'react',
+    },
+  },
 });


### PR DESCRIPTION
This PR adds a mechanism to load webscenes the same way as one can load layers:

```
<SceneView>
  <Scene>
    <Layer />
    <Layer />
    <Layer />
    <Webscene />
    <Webscene />
  <Scene>
</SceneView>
```

The layers from the webscene added to the scene as a single `LayerGroup`. The goal is to simplify loading/unloading of webscenes to the current map. 

### Syntax

```
<Webscene portalItem={{ id: 'abcd1234' }} visible={true} onLoad={callback} />
```

Additionally, if a `portalItem` is supplied which is a layer instead of a webscene, the component loads it anyway and acts as if the item were a webscene with that single layer. To this end, we can use the following magic function (which we should consider using in the `Layer` component as well):

```
const layer = await EsriLayer.fromPortalItem({ portalItem });
```

### Important!

While implementing this feature, I realized that `react` and `react-dom` were being compiled into the library distribution. I changed this by adding `react` as an external and by removing the `react-dom` dependency. `react-dom` isn't used by this library, only in the example. **TBD**: we should figure out how to fix the example.

You can check if `react` or `react-dom` have been imported twice by typing `npm ls react-dom` in your project folder. This duplication is resolved with this PR.

However, it still seems to initialize a second instance of `react-dom`, which prevents us from using hooks. (But at least now this second instance is using the same code as the main app.)

It would be nice if we could figure out why this is happening.