### PR TITLE
Bugfix/camera onchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.1.75",
+  "version": "0.2.4",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/event-listeners/camera/index.jsx
+++ b/src/event-listeners/camera/index.jsx
@@ -30,6 +30,8 @@ class CameraEventListener extends Component {
   }
 
   handleUpdate() {
+    if (!this.props.view.camera) return;
+
     this.props.onCameraChange({
       camera: {
         position: this.props.view.camera.position,


### PR DESCRIPTION
Due to some JS API timing issues it can happen that `camera` is not defined when the watcher calls the `onCameraChange` callback.

We assume that the `stationary` watcher is calling the callback before the `camera` is properly set or something like that...