### PR TITLE
Feature/sketch view model highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/tools/drawing-tool/index.js
+++ b/src/tools/drawing-tool/index.js
@@ -34,6 +34,7 @@ class DrawingTool extends Component {
       elevationInfo: { mode: 'on-the-ground' },
     });
     view.map.add(this.layer);
+    this.layerView = await view.whenLayerView(this.layer);
 
     this.model = new SketchViewModel({
       layer: this.layer,
@@ -47,14 +48,25 @@ class DrawingTool extends Component {
     }
 
     this.onCreate = this.model.on('create', (event) => {
-      if (event.state === 'complete') {
-        this.props.onDraw({
-          geometry: event.graphic.geometry,
-          area: 1,
-        });
-        this.model.update(event.graphic, { tool: 'reshape' });
-      } else if (event.state === 'cancel') {
-        this.onCancel();
+      switch (event.state) {
+        case 'start': {
+          this.layerView.highlight(event.graphic);
+          break;
+        }
+        case 'complete': {
+          this.props.onDraw({
+            geometry: event.graphic.geometry,
+            area: 1,
+          });
+          this.model.update(event.graphic, { tool: 'reshape' });
+          break;
+        }
+        case 'cancel': {
+          this.onCancel();
+          break;
+        }
+        default:
+          break;
       }
     });
 


### PR DESCRIPTION
This fixes https://zrh-web.esri.com/jira/browse/UP-2916.

Using JS API 4.15, the highlight only shows once the polygon has been closed. Jesse assured me that in JS API 4.16 it will also show the highlight before.

Until 4.16 this is a half-fix, but better than nothing.