### PR TITLE
Bugfix: rectangle selection: handle with starting/ending outside of the map (e.g., in the sky)

### DIFF
--- a/src/tools/rectangle-selection-tool/index.js
+++ b/src/tools/rectangle-selection-tool/index.js
@@ -72,8 +72,8 @@ class SelectionEventListener extends Component {
           }
 
           const { geometry, spatialRelationship } = await this.getGraphic();
-          this.doSelection(geometry, spatialRelationship, event);
           this.clearSelectionShape();
+          this.doSelection(geometry, spatialRelationship, event);
           break;
         }
       }


### PR DESCRIPTION
This line was broken:

```javascript
if (!mapPoint) return;
```

This needed more careful handling, if not it could end up trying to create a rectangle with `startPoint: null` or `endPoint: null`.