### PR TITLE
Bugfix: lasso selection: handle with starting/ending outside of the map (e.g., in the sky) bug

### DIFF
--- a/src/tools/lasso-selection-tool/index.js
+++ b/src/tools/lasso-selection-tool/index.js
@@ -58,10 +58,7 @@ class SelectionEventListener extends Component {
 
         case 'end':
         default: {
-          if (!mapPoint) {
-            this.clearSelectionShape();
-            break;
-          }
+          if (this.state.points.length === 0) break;
 
           const { geometry, spatialRelationship } = await this.getGraphic();
           this.clearSelectionShape();


### PR DESCRIPTION
Similar to #67 