### PR TITLE
Fix various linter and testing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": ">=16.9.0"
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -27,7 +28,7 @@
     "babel-loader": "^8.0.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "eslint": "^6.3.0",
+    "eslint": "7.3.1",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-loader": "^3.0.0",
     "eslint-plugin-import": "^2.18.2",
@@ -36,6 +37,7 @@
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "react": ">=16.9.0",
+    "react-dom": ">=16.9.0",
     "react-test-renderer": "^15.6.2",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.8",

--- a/src/__tests__/index.test.jsx
+++ b/src/__tests__/index.test.jsx
@@ -24,7 +24,6 @@ import { loadEsriSceneView } from '../load';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-
 jest.mock('../scene', () => (view, mode) => {
   if (!view || !mode) return null;
   return <div id="scene" />;
@@ -47,7 +46,6 @@ jest.mock('../load', () => ({
     watch: jest.fn(),
   })),
 }));
-
 
 describe('components', () => {
   describe('<SceneView />', () => {

--- a/src/__tests__/load.test.js
+++ b/src/__tests__/load.test.js
@@ -32,7 +32,6 @@ jest.mock('esri-loader', () => {
   };
 });
 
-
 describe('components', () => {
   describe('loadEsriSceneView', () => {
     const id = 'sceneview';

--- a/src/event-listeners/camera/index.jsx
+++ b/src/event-listeners/camera/index.jsx
@@ -49,16 +49,13 @@ class CameraEventListener extends Component {
   }
 }
 
-
 CameraEventListener.propTypes = {
   view: PropTypes.object,
   onCameraChange: PropTypes.func.isRequired,
 };
 
-
 CameraEventListener.defaultProps = {
   view: null,
 };
-
 
 export default CameraEventListener;

--- a/src/event-listeners/click/index.jsx
+++ b/src/event-listeners/click/index.jsx
@@ -21,9 +21,7 @@ import PropTypes from 'prop-types';
 
 import { handleSelectionQuery } from '../../helpers/handle-selection-query';
 
-
 let listener;
-
 
 const getSelectionGeometry = async (center) => {
   const [Circle] = await esriLoader.loadModules(['esri/geometry/Circle']);
@@ -33,7 +31,6 @@ const getSelectionGeometry = async (center) => {
   });
 };
 
-
 class ClickEventListener extends Component {
   async componentDidMount() {
     listener = this.props.view.on('click', async (event) => {
@@ -41,7 +38,6 @@ class ClickEventListener extends Component {
 
       const graphic = results && results[0] && results[0].graphic;
       const mapPoint = this.props.view.toMap(screenPoint);
-
 
       let features = [];
       if (mapPoint) {
@@ -85,16 +81,13 @@ class ClickEventListener extends Component {
   }
 }
 
-
 ClickEventListener.propTypes = {
   view: PropTypes.object,
   onClick: PropTypes.func.isRequired,
 };
 
-
 ClickEventListener.defaultProps = {
   view: null,
 };
-
 
 export default ClickEventListener;

--- a/src/event-listeners/mouse-move/index.jsx
+++ b/src/event-listeners/mouse-move/index.jsx
@@ -48,27 +48,22 @@ class MouseMoveEventListener extends Component {
     });
   }
 
-
   componentWillUnmount() {
     listener.remove();
   }
-
 
   render() {
     return null;
   }
 }
 
-
 MouseMoveEventListener.propTypes = {
   view: PropTypes.object,
   onMouseMove: PropTypes.func.isRequired,
 };
 
-
 MouseMoveEventListener.defaultProps = {
   view: null,
 };
-
 
 export default MouseMoveEventListener;

--- a/src/helpers/get-esri-geometry.js
+++ b/src/helpers/get-esri-geometry.js
@@ -16,7 +16,6 @@
 
 import esriLoader from 'esri-loader';
 
-
 export const getEsriGeometry = async (geometry) => {
   const [Polygon, Polyline, Point, Mesh] =
     await esriLoader.loadModules([
@@ -35,6 +34,5 @@ export const getEsriGeometry = async (geometry) => {
 
   return null;
 };
-
 
 export default getEsriGeometry;

--- a/src/helpers/handle-selection-query.js
+++ b/src/helpers/handle-selection-query.js
@@ -16,7 +16,6 @@
 
 import esriLoader from 'esri-loader';
 
-
 const getExtent = point => ({
   type: 'extent',
   spatialReference: point.spatialReference,
@@ -27,7 +26,6 @@ const getExtent = point => ({
   hasM: false,
   hasZ: false,
 });
-
 
 const queryFeaturesByGeometry = async (layerView, geometry, spatialRelationship) => {
   const [geometryEngine] = await esriLoader.loadModules(['esri/geometry/geometryEngine']);
@@ -51,7 +49,6 @@ const queryFeaturesByGeometry = async (layerView, geometry, spatialRelationship)
   return selectionFeatures;
 };
 
-
 const querySelectionFeatures = async (view, geometry, spatialRelationship) => {
   const layerViews = view.layerViews.items.filter(e => e.layer.selectable);
   if (layerViews.length < 1) return [];
@@ -62,7 +59,6 @@ const querySelectionFeatures = async (view, geometry, spatialRelationship) => {
   const results = await Promise.all(queries);
   return [].concat(...results);
 };
-
 
 export const handleSelectionQuery = async (view, selectionGeometry, spatialRelationship) => {
   const selectionFeatures =
@@ -80,6 +76,5 @@ export const handleSelectionQuery = async (view, selectionGeometry, spatialRelat
       layerId: feature.layer.id,
     }));
 };
-
 
 export default handleSelectionQuery;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -33,9 +33,7 @@ import AreaMeasurementTool from './tools/area-measurement-tool';
 import SliceTool from './tools/slice-tool';
 import LineOfSightTool from './tools/line-of-sight-tool';
 
-
 import { loadEsriSceneView } from './load';
-
 
 const getCameraFromProp = async (current, { center, position, heading, tilt, scale, target }) => {
   const camera = {};
@@ -49,7 +47,6 @@ const getCameraFromProp = async (current, { center, position, heading, tilt, sca
 };
 
 let animation;
-
 
 class SceneView extends Component {
   constructor(props) {
@@ -176,7 +173,6 @@ class SceneView extends Component {
     };
   }
 
-
   openPopup(params) {
     this.state.view.popup.open(params);
   }
@@ -250,7 +246,6 @@ class SceneView extends Component {
   }
 }
 
-
 SceneView.propTypes = {
   children: PropTypes.node,
   id: PropTypes.string.isRequired,
@@ -273,7 +268,6 @@ SceneView.propTypes = {
   onLoad: PropTypes.func,
 };
 
-
 SceneView.defaultProps = {
   children: null,
   environment: null,
@@ -294,7 +288,6 @@ SceneView.defaultProps = {
   onMouseMove: null,
   onLoad: null,
 };
-
 
 SceneView.Scene = Scene;
 SceneView.UI = UI;

--- a/src/legend/index.jsx
+++ b/src/legend/index.jsx
@@ -18,7 +18,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class Legend extends Component {
   constructor(props) {
     super(props);
@@ -41,7 +40,6 @@ class Legend extends Component {
     return <div ref={this.legendRef} />;
   }
 }
-
 
 Legend.propTypes = {
   sceneViewId: PropTypes.string.isRequired,

--- a/src/load.js
+++ b/src/load.js
@@ -16,9 +16,7 @@
 
 import esriLoader from 'esri-loader';
 
-
 const uiPositions = ['top-left', 'top-right', 'bottom-right', 'bottom-left'];
-
 
 export const loadEsriSceneView = async (componentRef, id, sceneviewSettings) => {
   if (!window.sceneViews) {
@@ -43,6 +41,5 @@ export const loadEsriSceneView = async (componentRef, id, sceneviewSettings) => 
 
   return view;
 };
-
 
 export default loadEsriSceneView;

--- a/src/scene/__tests__/index.test.jsx
+++ b/src/scene/__tests__/index.test.jsx
@@ -20,10 +20,10 @@ import Adapter from 'enzyme-adapter-react-16';
 import esriLoader from 'esri-loader';
 
 import Scene from '../index';
-import Layer from '../layer';
-import CustomBasemap from '../custom-basemap';
-import CustomElevationLayer from '../custom-elevation-layer';
-import SelectionLayer from '../selection-layer';
+// import Layer from '../layer';
+// import CustomBasemap from '../custom-basemap';
+// import CustomElevationLayer from '../custom-elevation-layer';
+// import SelectionLayer from '../selection-layer';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -63,7 +63,6 @@ const viewMock = {
   when: jest.fn(() => viewPromise),
 };
 
-
 describe('components', () => {
   describe('<Scene />', () => {
     it('should render self, load webscene, and attach it to view', async () => {
@@ -72,7 +71,7 @@ describe('components', () => {
         mode: 'nav',
         basemap: 'gray-vector',
         ground: 'world-elevation',
-        portalItem: { id: '1234' },
+        // portalItem: { id: '1234' },
         initialViewProperties: {
           environment: {
             lighting: {
@@ -97,8 +96,11 @@ describe('components', () => {
       await WebScene.prototype.load();
       expect(viewMock.when).toHaveBeenCalled();
 
-      // await viewMock.when();
-      // expect(wrapper.find('div').exists()).toBe(true);
+      await viewMock.when();
+
+      wrapper.update();
+
+      expect(wrapper.find('div').exists()).toBe(true);
     });
 
     // it('should render Children', (done) => {

--- a/src/scene/custom-basemap/index.jsx
+++ b/src/scene/custom-basemap/index.jsx
@@ -18,7 +18,6 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class CustomBasemap extends Component {
   componentDidMount() {
     this.loadBasemap();
@@ -49,7 +48,6 @@ class CustomBasemap extends Component {
   }
 }
 
-
 CustomBasemap.propTypes = {
   basemap: PropTypes.string,
   portalItem: PropTypes.object,
@@ -61,6 +59,5 @@ CustomBasemap.defaultProps = {
   portalItem: null,
   view: null,
 };
-
 
 export default CustomBasemap;

--- a/src/scene/custom-elevation-layer/index.jsx
+++ b/src/scene/custom-elevation-layer/index.jsx
@@ -18,7 +18,6 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class CustomElevationLayer extends Component {
   constructor(props) {
     super(props);
@@ -52,7 +51,6 @@ class CustomElevationLayer extends Component {
   }
 }
 
-
 CustomElevationLayer.propTypes = {
   url: PropTypes.string,
   portalItem: PropTypes.object,
@@ -64,6 +62,5 @@ CustomElevationLayer.defaultProps = {
   portalItem: null,
   view: null,
 };
-
 
 export default CustomElevationLayer;

--- a/src/scene/ground/index.jsx
+++ b/src/scene/ground/index.jsx
@@ -17,13 +17,11 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 
-
 const groundSettingsProps = {
   navigationConstraint: PropTypes.object,
   opacity: PropTypes.number,
   surfaceColor: PropTypes.node,
 };
-
 
 const getSettings = (props) => {
   const settings = {};
@@ -35,7 +33,6 @@ const getSettings = (props) => {
   return settings;
 };
 
-
 const getUpdates = (props, nextProps) => {
   const updates = {};
 
@@ -45,7 +42,6 @@ const getUpdates = (props, nextProps) => {
 
   return updates;
 };
-
 
 class Ground extends Component {
   constructor(props) {
@@ -66,12 +62,10 @@ class Ground extends Component {
   }
 }
 
-
 Ground.propTypes = {
   ...groundSettingsProps,
   view: PropTypes.object,
 };
-
 
 /* eslint react/default-props-match-prop-types: 0 */
 Ground.defaultProps = {
@@ -80,6 +74,5 @@ Ground.defaultProps = {
   surfaceColor: null,
   view: null,
 };
-
 
 export default Ground;

--- a/src/scene/index.jsx
+++ b/src/scene/index.jsx
@@ -25,7 +25,6 @@ import CustomBasemap from './custom-basemap';
 import CustomElevationLayer from './custom-elevation-layer';
 import SelectionLayer from './selection-layer';
 
-
 class Scene extends Component {
   constructor(props) {
     super(props);
@@ -91,7 +90,6 @@ class Scene extends Component {
     );
   }
 }
-
 
 Scene.propTypes = {
   children: PropTypes.node,

--- a/src/scene/layer/__tests__/index.test.jsx
+++ b/src/scene/layer/__tests__/index.test.jsx
@@ -57,7 +57,6 @@ jest.mock('../load', () => ({
   })),
 }));
 
-
 describe('components', () => {
   describe('<Layer />', () => {
     const layer = {

--- a/src/scene/layer/graphic/index.jsx
+++ b/src/scene/layer/graphic/index.jsx
@@ -17,7 +17,6 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 
-
 class Graphic extends Component {
   componentDidMount() {
     this.loadGraphic();
@@ -54,7 +53,6 @@ class Graphic extends Component {
   }
 }
 
-
 Graphic.propTypes = {
   layer: PropTypes.object.isRequired,
   geometry: PropTypes.object.isRequired,
@@ -62,10 +60,8 @@ Graphic.propTypes = {
   symbol: PropTypes.object,
 };
 
-
 Graphic.defaultProps = {
   symbol: null,
 };
-
 
 export default Graphic;

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -23,7 +23,6 @@ import layerSettingsProps from './layer-settings-props';
 import Graphic from './graphic';
 import { applyUpdates } from './update';
 
-
 const getLayerSettings = (props) => {
   const settings = {};
 
@@ -36,10 +35,8 @@ const getLayerSettings = (props) => {
   return settings;
 };
 
-
 const arrayCompare = (a, b) => !Array.isArray(a) || !Array.isArray(b) ||
   a.length !== b.length || !a.every(e => b.includes(e)) || !b.every(e => a.includes(e));
-
 
 class Layer extends Component {
   constructor(props) {
@@ -50,13 +47,11 @@ class Layer extends Component {
     };
   }
 
-
   componentDidMount() {
     this.componentIsMounted = true;
     const layerSettings = getLayerSettings(this.props);
     this.load(this.props.view, layerSettings);
   }
-
 
   componentDidUpdate(prevProps) {
     if (!this.state.layer) return;
@@ -76,7 +71,6 @@ class Layer extends Component {
     applyUpdates(prevProps, this.props, this.state.layer, this.state.layerView, this.esriUtils);
   }
 
-
   componentWillUnmount() {
     this.componentIsMounted = false;
     if (!this.state.layer) return;
@@ -88,7 +82,6 @@ class Layer extends Component {
 
     this.props.view.map.layers.remove(this.state.layer);
   }
-
 
   async initEsriUtils() {
     const [
@@ -108,7 +101,6 @@ class Layer extends Component {
     };
   }
 
-
   updateHighlights() {
     if (!this.state.layerView) return;
 
@@ -124,7 +116,6 @@ class Layer extends Component {
       this.highlights = null;
     }
   }
-
 
   async load(view, layerSettings) {
     if (!view) return;
@@ -170,7 +161,6 @@ class Layer extends Component {
   }
 }
 
-
 Layer.propTypes = {
   children: PropTypes.node,
   ...layerSettingsProps,
@@ -178,7 +168,6 @@ Layer.propTypes = {
   highlight: PropTypes.array,
   view: PropTypes.object,
 };
-
 
 /* eslint react/default-props-match-prop-types: 0 */
 Layer.defaultProps = {

--- a/src/scene/layer/load.js
+++ b/src/scene/layer/load.js
@@ -16,7 +16,6 @@
 
 import esriLoader from 'esri-loader';
 
-
 const layerTypes = {
   feature: 'esri/layers/FeatureLayer',
   scene: 'esri/layers/SceneLayer',
@@ -28,7 +27,6 @@ const layerTypes = {
   'point-cloud': 'esri/layers/PointCloudLayer',
   'building-scene': 'esri/layers/BuildingSceneLayer',
 };
-
 
 export const loadLayer = async ({
   id,
@@ -69,6 +67,5 @@ export const loadLayer = async ({
   const [Layer] = await esriLoader.loadModules([layerTypes[layerType]]);
   return new Layer(layerSettings);
 };
-
 
 export default loadLayer;

--- a/src/scene/layer/update.js
+++ b/src/scene/layer/update.js
@@ -15,7 +15,6 @@
  */
 import layerSettingsProps from './layer-settings-props';
 
-
 const getLayerUpdates = (prevProps, nextProps) => {
   const changes = Object
     .keys(layerSettingsProps)
@@ -30,7 +29,6 @@ const getLayerUpdates = (prevProps, nextProps) => {
 
   return updates;
 };
-
 
 export const applyUpdates = (prevProps, nextProps, layer, layerView, esriUtils) => {
   const updatesDiff = getLayerUpdates(prevProps, nextProps);
@@ -78,6 +76,5 @@ export const applyUpdates = (prevProps, nextProps, layer, layerView, esriUtils) 
     }) : null;
   }
 };
-
 
 export default applyUpdates;

--- a/src/scene/selection-layer/index.js
+++ b/src/scene/selection-layer/index.js
@@ -20,7 +20,6 @@ import esriLoader from 'esri-loader';
 
 import selectionLayerSettings from './selection-layer-settings';
 
-
 class SelectionLayer extends Component {
   async componentDidMount() {
     const [GraphicsLayer] = await esriLoader.loadModules(['esri/layers/GraphicsLayer']);
@@ -31,22 +30,18 @@ class SelectionLayer extends Component {
     }));
   }
 
-
   render() {
     return null;
   }
 }
-
 
 SelectionLayer.propTypes = {
   id: PropTypes.string.isRequired,
   view: PropTypes.object,
 };
 
-
 SelectionLayer.defaultProps = {
   view: null,
 };
-
 
 export default SelectionLayer;

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -18,7 +18,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class Webscene extends Component {
   constructor(props) {
     super(props);
@@ -27,24 +26,20 @@ class Webscene extends Component {
     };
   }
 
-
   componentDidMount() {
     this.componentIsMounted = true;
     this.loadWebscene();
   }
 
-
   componentDidUpdate(prevProps) {
     this.update(prevProps);
   }
-
 
   componentWillUnmount() {
     if (!this.props.view || !this.props.view.map) return;
     this.componentIsMounted = false;
     this.props.view.map.remove(this.state.groupLayer);
   }
-
 
   update(prevProps = {}) {
     if (!this.props.view || !this.state.groupLayer) return;
@@ -63,7 +58,6 @@ class Webscene extends Component {
       });
     }
   }
-
 
   async loadWebscene() {
     if (!this.props.view || !this.props.view.map) return;
@@ -113,7 +107,6 @@ class Webscene extends Component {
   }
 }
 
-
 Webscene.propTypes = {
   portalItem: PropTypes.object.isRequired,
   view: PropTypes.object,
@@ -122,13 +115,11 @@ Webscene.propTypes = {
   layerSettings: PropTypes.object,
 };
 
-
 Webscene.defaultProps = {
   view: null,
   visible: true,
   onLoad: null,
   layerSettings: {},
 };
-
 
 export default Webscene;

--- a/src/tools/area-measurement-tool/index.js
+++ b/src/tools/area-measurement-tool/index.js
@@ -19,7 +19,6 @@ import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 import unitOptions from '../../helpers/unit-options';
 
-
 class AreaMeasurementTool extends Component {
   async componentDidMount() {
     this.componentIsMounted = true;
@@ -65,6 +64,5 @@ AreaMeasurementTool.defaultProps = {
   unit: 'metric',
   view: null,
 };
-
 
 export default AreaMeasurementTool;

--- a/src/tools/distance-measurement-tool/index.js
+++ b/src/tools/distance-measurement-tool/index.js
@@ -19,7 +19,6 @@ import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 import unitOptions from '../../helpers/unit-options';
 
-
 class DistanceMeasurementTool extends Component {
   async componentDidMount() {
     this.componentIsMounted = true;
@@ -67,6 +66,5 @@ DistanceMeasurementTool.defaultProps = {
   unit: 'metric',
   view: null,
 };
-
 
 export default DistanceMeasurementTool;

--- a/src/tools/drawing-tool/index.js
+++ b/src/tools/drawing-tool/index.js
@@ -154,7 +154,6 @@ class DrawingTool extends Component {
   }
 }
 
-
 DrawingTool.propTypes = {
   onDraw: PropTypes.func,
   geometryType: PropTypes.oneOf(['point', 'multipoint', 'polyline', 'polygon', 'rectangle', 'circle']),
@@ -163,7 +162,6 @@ DrawingTool.propTypes = {
   geometry: PropTypes.object,
 };
 
-
 DrawingTool.defaultProps = {
   geometryType: 'polygon',
   mode: 'click',
@@ -171,6 +169,5 @@ DrawingTool.defaultProps = {
   geometry: null,
   onDraw: () => null,
 };
-
 
 export default DrawingTool;

--- a/src/tools/lasso-selection-tool/index.js
+++ b/src/tools/lasso-selection-tool/index.js
@@ -109,12 +109,10 @@ class SelectionEventListener extends Component {
   }
 }
 
-
 SelectionEventListener.propTypes = {
   view: PropTypes.object,
   onSelect: PropTypes.func.isRequired,
 };
-
 
 SelectionEventListener.defaultProps = {
   view: null,

--- a/src/tools/line-of-sight-tool/index.js
+++ b/src/tools/line-of-sight-tool/index.js
@@ -52,5 +52,4 @@ LineOfSightTool.defaultProps = {
   view: null,
 };
 
-
 export default LineOfSightTool;

--- a/src/tools/line-selection-tool/get-graphic-from-line.js
+++ b/src/tools/line-selection-tool/get-graphic-from-line.js
@@ -16,7 +16,6 @@
 
 import getEsriGeometry from '../../helpers/get-esri-geometry';
 
-
 export const getGraphicFromLine = async (startPoint, endPoint) => ({
   attributes: {
     ObjectID: 0,
@@ -36,6 +35,5 @@ export const getGraphicFromLine = async (startPoint, endPoint) => ({
     width: '3px',
   },
 });
-
 
 export default getGraphicFromLine;

--- a/src/tools/line-selection-tool/index.js
+++ b/src/tools/line-selection-tool/index.js
@@ -76,7 +76,6 @@ class SelectionEventListener extends Component {
     listener.remove();
   }
 
-
   getGraphic() {
     return getGraphicFromLine(this.state.startPoint, this.state.endPoint);
   }
@@ -104,7 +103,6 @@ class SelectionEventListener extends Component {
   async doSelection(geometry, spatialRelationship, event) {
     const features = await handleSelectionQuery(this.props.view, geometry, spatialRelationship);
 
-
     this.props.onSelect({
       features,
       event: { ...event, geometry, spatialRelationship },
@@ -116,16 +114,13 @@ class SelectionEventListener extends Component {
   }
 }
 
-
 SelectionEventListener.propTypes = {
   view: PropTypes.object,
   onSelect: PropTypes.func.isRequired,
 };
 
-
 SelectionEventListener.defaultProps = {
   view: null,
 };
-
 
 export default SelectionEventListener;

--- a/src/tools/rectangle-selection-tool/get-graphic-from-rectangle.js
+++ b/src/tools/rectangle-selection-tool/get-graphic-from-rectangle.js
@@ -15,7 +15,6 @@
  */
 import esriLoader from 'esri-loader';
 
-
 export const getGraphicFromRectangle = async (startPoint, endPoint, heading) => {
   const [Polygon, Polyline, geometryEngine] = await esriLoader.loadModules([
     'esri/geometry/Polygon',

--- a/src/tools/rectangle-selection-tool/index.js
+++ b/src/tools/rectangle-selection-tool/index.js
@@ -84,7 +84,6 @@ class SelectionEventListener extends Component {
     listener.remove();
   }
 
-
   getGraphic() {
     return getGraphicFromRectangle(this.state.startPoint, this.state.endPoint, this.state.heading);
   }
@@ -112,7 +111,6 @@ class SelectionEventListener extends Component {
   async doSelection(geometry, spatialRelationship, event) {
     const features = await handleSelectionQuery(this.props.view, geometry, spatialRelationship);
 
-
     this.props.onSelect({
       features,
       event: { ...event, geometry, spatialRelationship },
@@ -124,16 +122,13 @@ class SelectionEventListener extends Component {
   }
 }
 
-
 SelectionEventListener.propTypes = {
   view: PropTypes.object,
   onSelect: PropTypes.func.isRequired,
 };
 
-
 SelectionEventListener.defaultProps = {
   view: null,
 };
-
 
 export default SelectionEventListener;

--- a/src/tools/slice-tool/index.js
+++ b/src/tools/slice-tool/index.js
@@ -18,7 +18,6 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class SliceTool extends Component {
   async componentDidMount() {
     this.componentIsMounted = true;

--- a/src/ui/compass/index.jsx
+++ b/src/ui/compass/index.jsx
@@ -18,7 +18,6 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class Compass extends Component {
   constructor(props) {
     super(props);
@@ -50,17 +49,14 @@ class Compass extends Component {
   }
 }
 
-
 Compass.propTypes = {
   position: PropTypes.string,
   view: PropTypes.object,
 };
 
-
 Compass.defaultProps = {
   position: 'top-left',
   view: null,
 };
-
 
 export default Compass;

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -34,7 +34,6 @@ class UI extends Component {
     this.props.view.ui.padding = this.props.padding;
   }
 
-
   renderWrappedChildren(children) {
     return React.Children.map(children, (child) => {
       // This is support for non-node elements (eg. pure text), they have no props
@@ -55,7 +54,6 @@ class UI extends Component {
     });
   }
 
-
   render() {
     return this.props.view && (
       <React.Fragment>
@@ -64,7 +62,6 @@ class UI extends Component {
     );
   }
 }
-
 
 UI.propTypes = {
   padding: PropTypes.shape({
@@ -77,7 +74,6 @@ UI.propTypes = {
   view: PropTypes.object,
 };
 
-
 UI.defaultProps = {
   padding: {
     top: 15,
@@ -88,7 +84,6 @@ UI.defaultProps = {
   children: [],
   view: null,
 };
-
 
 UI.Compass = Compass;
 UI.NavigationToggle = NavigationToggle;

--- a/src/ui/navigation-toggle/index.jsx
+++ b/src/ui/navigation-toggle/index.jsx
@@ -18,7 +18,6 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class NavigationToggle extends Component {
   constructor(props) {
     super(props);
@@ -48,17 +47,14 @@ class NavigationToggle extends Component {
   }
 }
 
-
 NavigationToggle.propTypes = {
   position: PropTypes.string,
   view: PropTypes.object,
 };
 
-
 NavigationToggle.defaultProps = {
   position: 'top-left',
   view: null,
 };
-
 
 export default NavigationToggle;

--- a/src/ui/zoom/index.jsx
+++ b/src/ui/zoom/index.jsx
@@ -18,7 +18,6 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 
-
 class Zoom extends Component {
   constructor(props) {
     super(props);
@@ -55,19 +54,16 @@ class Zoom extends Component {
   }
 }
 
-
 Zoom.propTypes = {
   position: PropTypes.oneOf(['top-left', 'top-right', 'bottom-right', 'bottom-left']),
   layout: PropTypes.oneOf(['horizontal', 'vertical']),
   view: PropTypes.object,
 };
 
-
 Zoom.defaultProps = {
   position: 'top-left',
   layout: 'vertical',
   view: null,
 };
-
 
 export default Zoom;


### PR DESCRIPTION
- Set `eslint` version to 7.3.1 without caret. (Caret causes problems in linter when new rules are introduced)
- Fix linter errors
- Add react-dom to `peerDependencies`
- Fix tests for scene component