### PR TITLE
Catch error message when portal item cannot be loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -81,7 +81,9 @@ class Webscene extends Component {
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
       try {
-        const layer = await EsriLayer.fromPortalItem({ portalItem: this.props.portalItem });
+        const layer = await EsriLayer.fromPortalItem({ portalItem: this.props.portalItem }).catch(() => {
+          // nevermind
+        });;
         layers.push(layer);
       } catch (e) {
         // give up

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -83,6 +83,7 @@ class Webscene extends Component {
 
       layers.push(...webscene.layers.items);
     } catch (err) {
+      if (err.message === 'Failed to load portal item') return;
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
       try {
         const layer = await EsriLayer.fromPortalItem({ portalItem: this.props.portalItem });

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -73,11 +73,12 @@ class Webscene extends Component {
 
     try {
       const webscene = new EsriWebScene({ portalItem: this.props.portalItem });
-      await webscene.load();
+      await webscene.load().catch(() => {
+        // nevermind
+      });
 
       layers.push(...webscene.layers.items);
     } catch (err) {
-      if (err.message === 'Failed to load portal item') return;
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
       try {
         const layer = await EsriLayer.fromPortalItem({ portalItem: this.props.portalItem });


### PR DESCRIPTION
I added an early return for when fetching a webscene item fails (e.g. when the webscene items has been deleted), so it does not try to load it from a layer as well (which will fail too).

This fixes: https://zrh-web.esri.com/jira/browse/UP-3352