### PR TITLE
Layer loading: remove dependency on hardcoded list of layer types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/layer/load.js
+++ b/src/scene/layer/load.js
@@ -18,7 +18,14 @@ import esriLoader from 'esri-loader';
 
 const layerTypes = {
   feature: 'esri/layers/FeatureLayer',
+  scene: 'esri/layers/SceneLayer',
   graphics: 'esri/layers/GraphicsLayer',
+  tile: 'esri/layers/TileLayer',
+  'vector-tile': 'esri/layers/VectorTileLayer',
+  'web-tile': 'esri/layers/WebTileLayer',
+  'integrated-mesh': 'esri/layers/IntegratedMeshLayer',
+  'point-cloud': 'esri/layers/PointCloudLayer',
+  'building-scene': 'esri/layers/BuildingSceneLayer',
 };
 
 export const loadLayer = async ({


### PR DESCRIPTION
This refactor leverages `EsriLayer.fromArcGISServerUrl({ url })` and `EsriLayer.fromPortalItem({ portalItem })` to avoid dependency on a hardcoded list of layer types.

Unfortunately, the hardcoded list is still needed for _source layers_. Even though _source layers_ should strictly be `GraphicsLayer` or `FeatureLayer`, both streetview layers are making an extremely shady use of _source layers_.

It would require a separate refactor of these streetview layers before the hardcoded list of layer types could be removed completely.

Nevertheless, with this refactor we shouldn't run into unsupported layer types anymore.