### PR TITLE
Load ground layers from webscenes

### DIFF
--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -70,12 +70,14 @@ class Webscene extends Component {
     if (!this.componentIsMounted) return;
 
     const layers = [];
+    const groundLayers = [];
 
     try {
       const webscene = new EsriWebScene({ portalItem: this.props.portalItem });
       await webscene.load();
 
       layers.push(...webscene.layers.items);
+      groundLayers.push(...webscene.ground.layers.items);
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
       try {
@@ -93,6 +95,8 @@ class Webscene extends Component {
     this.setState({ groupLayer });
     this.state.groupLayer.addMany(layers);
     this.props.view.map.layers.add(groupLayer);
+
+    this.props.view.map.ground.layers.addMany(groundLayers);
 
     await this.props.view.whenLayerView(groupLayer);
     this.update();


### PR DESCRIPTION
This PR adds functionality to fetch the ground layers (of type `ElevationLayer`) from webscenes and adds them to the `view.map.ground`.

Before:

![image](https://user-images.githubusercontent.com/27951811/86941405-31766100-c144-11ea-964f-20d56209851d.png)

After:

![image](https://user-images.githubusercontent.com/27951811/86940696-6cc46000-c143-11ea-8998-2baa859a18d8.png)
