### PR TITLE
Integrated Mesh: Add maskingGeometry as clip to layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -88,16 +88,22 @@ class Layer extends Component {
       FeatureFilter,
       Polygon,
       rendererJsonUtils,
+      SceneModifications,
+      SceneModification,
     ] = await esriLoader.loadModules([
       'esri/views/layers/support/FeatureFilter',
       'esri/geometry/Polygon',
       'esri/renderers/support/jsonUtils',
+      'esri/layers/support/SceneModifications',
+      'esri/layers/support/SceneModification',
     ]);
 
     this.esriUtils = {
       FeatureFilter,
       Polygon,
       rendererJsonUtils,
+      SceneModifications,
+      SceneModification,
     };
   }
 

--- a/src/scene/layer/update.js
+++ b/src/scene/layer/update.js
@@ -68,10 +68,13 @@ export const applyUpdates = (prevProps, nextProps, layer, layerView, esriUtils) 
   }
 
   if (maskingGeometry !== undefined) {
-    const polygon = nextProps.maskingGeometry ?
-      new esriUtils.Polygon(nextProps.maskingGeometry) : null;
+    if (!nextProps.maskingGeometry) {
+      if (layerView) layerView.filter = null;
+      layer.modifications = null;
+      return;
+    }
 
-    if (!polygon) return;
+    const polygon = new esriUtils.Polygon(nextProps.maskingGeometry);
 
     if (layer.type === 'scene' && layerView) {
       layerView.filter = new esriUtils.FeatureFilter({

--- a/src/scene/layer/update.js
+++ b/src/scene/layer/update.js
@@ -68,12 +68,25 @@ export const applyUpdates = (prevProps, nextProps, layer, layerView, esriUtils) 
   }
 
   if (maskingGeometry !== undefined) {
-    if (!layerView) return;
+    const polygon = nextProps.maskingGeometry ?
+      new esriUtils.Polygon(nextProps.maskingGeometry) : null;
 
-    layerView.filter = nextProps.maskingGeometry ? new esriUtils.FeatureFilter({
-      geometry: new esriUtils.Polygon(nextProps.maskingGeometry),
-      spatialRelationship: 'disjoint',
-    }) : null;
+    if (!polygon) return;
+
+    if (layer.type === 'scene' && layerView) {
+      layerView.filter = new esriUtils.FeatureFilter({
+        geometry: polygon,
+        spatialRelationship: 'disjoint',
+      });
+    }
+
+    if (layer.type === 'integrated-mesh') {
+      layer.modifications = new esriUtils.SceneModifications(
+        [
+          new esriUtils.SceneModification({ geometry: polygon, type: 'clip' }),
+        ],
+      );
+    }
   }
 };
 


### PR DESCRIPTION
This PR adds logic to apply the maskingGeometry as a scene [modification ](https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-IntegratedMeshLayer.html#modifications )of type `clip` to an integrated mesh layer.

This functionality has become available with the JS API 4.16.