### PR TITLE
Feature/lasso always intersect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/tools/lasso-selection-tool/get-graphic-from-lasso-points.js
+++ b/src/tools/lasso-selection-tool/get-graphic-from-lasso-points.js
@@ -50,7 +50,7 @@ export const getGraphicFromLassoPoints = async (polyPoints) => {
       ],
       spatialReference: { wkid: 3857 },
     }),
-    spatialRelationship: 'esriSpatialRelContains',
+    spatialRelationship: 'esriSpatialRelIntersects',
     symbol: {
       type: 'simple-fill', // autocasts as new SimpleFillSymbol()
       color: [0, 255, 255, 0.5],


### PR DESCRIPTION
https://zrh-web.esri.com/jira/browse/UP-3416

It is requested by everyone (@lisastaehli , Brooks etc.) that this lasso tool always uses `esriSpatialRelIntersects` and not `esriSpatialRelContains`.