### PR TITLE
Catch fromPortalItem error

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -4,8 +4,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no"/>
     <title>react-sceneview</title>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/css/main.css">
-    <script src="https://js.arcgis.com/4.12/"></script>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.16/esri/css/main.css">
+    <script src="https://js.arcgis.com/4.16/"></script>
   </head>
   <body style="margin: 0">
     <div id="root" style="width: 100vw; height: 100vh;"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -130,7 +130,14 @@ class Layer extends Component {
 
     // Check if already exists (e.g., after hot reload)
     const existingLayer = view.map.layers.items.find(l => l.id === layerSettings.id);
-    const layer = existingLayer || await loadLayer(layerSettings);
+    let layer;
+
+    try {
+      layer = existingLayer || await loadLayer(layerSettings);
+    } catch (error) {
+      // Don't try to continue and add layer to map if layer cannot be loaded (e.g. does not exist)
+      return;
+    }
 
     // After every await, need to check if component is still mounted
     if (!this.componentIsMounted || !layer) return;


### PR DESCRIPTION
`EsriLayer.fromPortalItem` in `loadLayer` throws an error when the portal item cannot be found:
https://devtopia.esri.com/WebGIS/arcgis-js-api/blob/1f5d15678208f2319eafacab6a902fb6ae926dce/esri/layers/Layer.ts#L316

This error should be caught and we should not attempt to add the layer to the view, but rather abort.

To test add a layer with portalItem that does not exist:

```javascript
     <Layer
        id="buildings"
        layerType="scene"
        selectable
        portalItem={{
          id: 'abcde519e21a4835913f69c4472bf44c',
        }}
     />
```