### PR TITLE
make AreaMeasurementTool more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/tools/area-measurement-tool/index.js
+++ b/src/tools/area-measurement-tool/index.js
@@ -36,7 +36,12 @@ class AreaMeasurementTool extends Component {
     this.measurementTool.viewModel.newMeasurement();
 
     this.watcher = this.measurementTool.view.on('click', () => {
-      if (this.measurementTool.viewModel.measurement.area.state === 'available') {
+      if (
+        this.measurementTool &&
+        this.measurementTool.viewModel &&
+        this.measurementTool.viewModel.measurement &&
+        this.measurementTool.viewModel.measurement.area &&
+        this.measurementTool.viewModel.measurement.area.state === 'available') {
         this.props.onChange(this.measurementTool.viewModel.measurement);
       }
     });


### PR DESCRIPTION
When right-clicking, it could happen that `this.measurementTool.viewModel.measurement === null`. The syntax proposed in this PR is better practice to handle such problems.