### PR TITLE
Drawing tool: enabled snapping (for v4.18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/tools/drawing-tool/index.js
+++ b/src/tools/drawing-tool/index.js
@@ -41,6 +41,8 @@ class DrawingTool extends Component {
       view,
     });
 
+    this.model.snappingOptions.selfEnabled = true;
+
     if (isValidGeometry(geometry)) {
       this.setGraphic(geometry);
     } else {


### PR DESCRIPTION
The new snapping feature that's coming in 4.18 is disabled by default, setting it to true for the SketchViewModel in `DrawingTool`