### PR TITLE
Refactor: Add prettier & pre-commit hook 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
     'react/jsx-fragments': 0,
     'react/jsx-wrap-multilines': 0,
     'react/jsx-props-no-spreading': 0,
+    'operator-linebreak': 0,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,14 +4,12 @@ module.exports = {
     es6: true,
     jest: true,
   },
-  extends: [
-    'airbnb',
-  ],
+  extends: ['airbnb', 'prettier'],
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2018,
-    ecmaFeatures : {
-      jsx : true,
+    ecmaFeatures: {
+      jsx: true,
     },
   },
   rules: {
@@ -21,12 +19,12 @@ module.exports = {
     'implicit-arrow-linebreak': 0,
     'arrow-parens': 0,
     'prefer-destructuring': 0,
-    'object-curly-newline' :0,
+    'object-curly-newline': 0,
     'import/no-named-as-default': 0,
     'react/destructuring-assignment': 0,
     'react/forbid-prop-types': 0,
     'react/no-access-state-in-setstate': 0,
-    'react/jsx-fragments' :0,
+    'react/jsx-fragments': 0,
     'react/jsx-wrap-multilines': 0,
     'react/jsx-props-no-spreading': 0,
   },

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ deploy/*
 target/*
 .vscode/*
 .DS_Store
+.eslintcache
 package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "avoid"
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "lint-staged"
     }
   },
   "author": "Michael Van den Bergh",
@@ -44,8 +44,8 @@
     "husky": "^4.3.7",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
+    "lint-staged": "^10.5.3",
     "prettier": "2.2.1",
-    "pretty-quick": "^3.1.0",
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0",
     "react-test-renderer": "^15.6.2",
@@ -53,5 +53,9 @@
     "webpack-cli": "^3.3.8",
     "webpack-dev-server": "^3.8.0",
     "webpack-merge": "^4.2.2"
+  },
+  "lint-staged": {
+    "*.{jsx,js}": "eslint --cache --fix",
+    "*.--write": "prettier --write"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,13 @@
     "start": "webpack-dev-server --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "test": "jest",
-    "lint": "./node_modules/.bin/eslint --ext .jsx,.js src/**"
+    "lint": "./node_modules/.bin/eslint --ext .jsx,.js src/**",
+    "format": "prettier \"src/**\" --write"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   },
   "author": "Michael Van den Bergh",
   "license": "Apache License - 2.0",
@@ -34,9 +40,11 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",
+    "husky": "^4.3.7",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "prettier": "2.2.1",
+    "pretty-quick": "^3.1.0",
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0",
     "react-test-renderer": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "7.3.1",
     "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^7.1.0",
     "eslint-loader": "^3.0.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-react": "^7.14.3",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
+    "prettier": "2.2.1",
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0",
     "react-test-renderer": "^15.6.2",

--- a/src/__tests__/index.test.jsx
+++ b/src/__tests__/index.test.jsx
@@ -41,10 +41,12 @@ jest.mock('../event-listeners', () => ({
 }));
 
 jest.mock('../load', () => ({
-  loadEsriSceneView: jest.fn(() => Promise.resolve({
-    on: jest.fn(),
-    watch: jest.fn(),
-  })),
+  loadEsriSceneView: jest.fn(() =>
+    Promise.resolve({
+      on: jest.fn(),
+      watch: jest.fn(),
+    }),
+  ),
 }));
 
 describe('components', () => {

--- a/src/__tests__/load.test.js
+++ b/src/__tests__/load.test.js
@@ -43,12 +43,25 @@ describe('components', () => {
       await loadEsriSceneView(componentRef, id, sceneviewSettings);
       expect(componentRef.appendChild).toHaveBeenCalled();
       const container = componentRef.appendChild.mock.calls[0][0];
-      expect(esriLoader.loadModules).toHaveBeenCalledWith(['esri/views/SceneView']);
-      expect(esriLoader.SceneView).toHaveBeenCalledWith({ container, ...sceneviewSettings });
-      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith('top-left');
-      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith('top-right');
-      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith('bottom-left');
-      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith('bottom-right');
+      expect(esriLoader.loadModules).toHaveBeenCalledWith([
+        'esri/views/SceneView',
+      ]);
+      expect(esriLoader.SceneView).toHaveBeenCalledWith({
+        container,
+        ...sceneviewSettings,
+      });
+      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith(
+        'top-left',
+      );
+      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith(
+        'top-right',
+      );
+      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith(
+        'bottom-left',
+      );
+      expect(esriLoader.SceneView.prototype.ui.empty).toHaveBeenCalledWith(
+        'bottom-right',
+      );
     });
   });
 });

--- a/src/event-listeners/camera/index.jsx
+++ b/src/event-listeners/camera/index.jsx
@@ -22,7 +22,9 @@ const listeners = [];
 class CameraEventListener extends Component {
   componentDidMount() {
     listeners.push(this.props.view.watch('camera', () => this.handleUpdate()));
-    listeners.push(this.props.view.watch('stationary', () => this.handleUpdate()));
+    listeners.push(
+      this.props.view.watch('stationary', () => this.handleUpdate()),
+    );
   }
 
   componentWillUnmount() {

--- a/src/event-listeners/click/index.jsx
+++ b/src/event-listeners/click/index.jsx
@@ -23,7 +23,7 @@ import { handleSelectionQuery } from '../../helpers/handle-selection-query';
 
 let listener;
 
-const getSelectionGeometry = async (center) => {
+const getSelectionGeometry = async center => {
   const [Circle] = await esriLoader.loadModules(['esri/geometry/Circle']);
   return new Circle({
     center,
@@ -33,22 +33,28 @@ const getSelectionGeometry = async (center) => {
 
 class ClickEventListener extends Component {
   async componentDidMount() {
-    listener = this.props.view.on('click', async (event) => {
-      const { results, screenPoint } = await this.props.view.hitTest({ x: event.x, y: event.y });
+    listener = this.props.view.on('click', async event => {
+      const { results, screenPoint } = await this.props.view.hitTest({
+        x: event.x,
+        y: event.y,
+      });
 
-      const graphics = results && results[0] ? results
-        .map(result => result.graphic)
-        .filter(graphic => graphic.layer && graphic.layer.selectable)
-        .map(graphic => ({
-          attributes: {
-            ...graphic.attributes,
-            esriObjectId: graphic.attributes[graphic.layer.objectIdField],
-          },
-          geometry: graphic.geometry,
-          GlobalID: graphic.attributes.GlobalID,
-          objectId: graphic.attributes[graphic.layer.objectIdField],
-          layerId: graphic.layer && graphic.layer.id,
-        })) : [];
+      const graphics =
+        results && results[0]
+          ? results
+              .map(result => result.graphic)
+              .filter(graphic => graphic.layer && graphic.layer.selectable)
+              .map(graphic => ({
+                attributes: {
+                  ...graphic.attributes,
+                  esriObjectId: graphic.attributes[graphic.layer.objectIdField],
+                },
+                geometry: graphic.geometry,
+                GlobalID: graphic.attributes.GlobalID,
+                objectId: graphic.attributes[graphic.layer.objectIdField],
+                layerId: graphic.layer && graphic.layer.id,
+              }))
+          : [];
 
       const mapPoint = this.props.view.toMap(screenPoint);
 

--- a/src/event-listeners/mouse-move/index.jsx
+++ b/src/event-listeners/mouse-move/index.jsx
@@ -21,11 +21,14 @@ let listener;
 
 class MouseMoveEventListener extends Component {
   async componentDidMount() {
-    listener = this.props.view.on('pointer-move', async (event) => {
+    listener = this.props.view.on('pointer-move', async event => {
       // don't trigger while navigating the scene
       if (this.props.view.interacting) return;
 
-      const { results } = await this.props.view.hitTest({ x: event.x, y: event.y });
+      const { results } = await this.props.view.hitTest({
+        x: event.x,
+        y: event.y,
+      });
 
       const graphic = results && results[0] && results[0].graphic;
       const mapPoint = this.props.view.toMap({ x: event.x, y: event.y });

--- a/src/helpers/get-esri-geometry.js
+++ b/src/helpers/get-esri-geometry.js
@@ -16,14 +16,13 @@
 
 import esriLoader from 'esri-loader';
 
-export const getEsriGeometry = async (geometry) => {
-  const [Polygon, Polyline, Point, Mesh] =
-    await esriLoader.loadModules([
-      'esri/geometry/Polygon',
-      'esri/geometry/Polyline',
-      'esri/geometry/Point',
-      'esri/geometry/Mesh',
-    ]);
+export const getEsriGeometry = async geometry => {
+  const [Polygon, Polyline, Point, Mesh] = await esriLoader.loadModules([
+    'esri/geometry/Polygon',
+    'esri/geometry/Polyline',
+    'esri/geometry/Point',
+    'esri/geometry/Mesh',
+  ]);
 
   if (geometry.rings) return new Polygon(geometry);
   if (geometry.paths) return new Polyline(geometry);

--- a/src/helpers/unit-options.js
+++ b/src/helpers/unit-options.js
@@ -1,1 +1,12 @@
-export default ['imperial', 'metric', 'inches', 'feet', 'yards', 'miles', 'nautical-miles', 'meters', 'kilometers', 'us-feet'];
+export default [
+  'imperial',
+  'metric',
+  'inches',
+  'feet',
+  'yards',
+  'miles',
+  'nautical-miles',
+  'meters',
+  'kilometers',
+  'us-feet',
+];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,7 +36,10 @@ import LineOfSightTool from './tools/line-of-sight-tool';
 
 import { loadEsriSceneView } from './load';
 
-const getCameraFromProp = async (current, { center, position, heading, tilt, scale, target }) => {
+const getCameraFromProp = async (
+  current,
+  { center, position, heading, tilt, scale, target },
+) => {
   const camera = {};
   if (position && current.position !== position) camera.position = position;
   if (center && current.center !== center) camera.center = center;
@@ -53,8 +56,11 @@ class SceneView extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      view: (window.sceneViews && window.sceneViews[this.props.id] &&
-        window.sceneViews[this.props.id].view) || null,
+      view:
+        (window.sceneViews &&
+          window.sceneViews[this.props.id] &&
+          window.sceneViews[this.props.id].view) ||
+        null,
     };
   }
 
@@ -67,15 +73,19 @@ class SceneView extends Component {
     this.loadSceneView();
   }
 
-  async UNSAFE_componentWillUpdate(nextProps) { // eslint-disable-line camelcase
+  async UNSAFE_componentWillUpdate(nextProps) {
+    // eslint-disable-line camelcase
     if (!this.state.view) return;
 
     if (this.props.environment !== nextProps.environment) {
       const environment = this.parseEnvironment(nextProps.environment);
-      Object.keys(environment).forEach(key => this.state.view.environment[key] = {
-        ...this.state.view.environment[key],
-        ...environment[key],
-      });
+      Object.keys(environment).forEach(
+        key =>
+          (this.state.view.environment[key] = {
+            ...this.state.view.environment[key],
+            ...environment[key],
+          }),
+      );
     }
 
     if (this.props.qualityProfile !== nextProps.qualityProfile) {
@@ -93,13 +103,18 @@ class SceneView extends Component {
       }
     }
 
-    if (this.props.goToLayers !== nextProps.goToLayers &&
-      nextProps.goToLayers && nextProps.goToLayers.length > 0) {
+    if (
+      this.props.goToLayers !== nextProps.goToLayers &&
+      nextProps.goToLayers &&
+      nextProps.goToLayers.length > 0
+    ) {
       const layers = nextProps.goToLayers
         .map(id => this.state.view.map.layers.items.find(i => i.id === id))
         .filter(layer => layer);
 
-      const extentResults = await Promise.all(layers.map(layer => layer.queryExtent()));
+      const extentResults = await Promise.all(
+        layers.map(layer => layer.queryExtent()),
+      );
       const extents = extentResults
         .filter(({ count }) => count > 0)
         .map(({ extent }) => extent);
@@ -114,11 +129,16 @@ class SceneView extends Component {
       if (this.state.view.interacting) return;
       if (!nextProps.turntable || !nextProps.turntable.target) return;
 
-      const camera = await getCameraFromProp(this.props.turntable, nextProps.turntable);
+      const camera = await getCameraFromProp(
+        this.props.turntable,
+        nextProps.turntable,
+      );
       await this.state.view.goTo(camera);
 
-      const [scheduling, watchUtils] =
-        await esriLoader.loadModules(['esri/core/scheduling', 'esri/core/watchUtils']);
+      const [scheduling, watchUtils] = await esriLoader.loadModules([
+        'esri/core/scheduling',
+        'esri/core/watchUtils',
+      ]);
 
       const view = this.state.view;
       const target = nextProps.turntable.target;
@@ -126,10 +146,13 @@ class SceneView extends Component {
       animation = scheduling.addFrameTask({
         update: () => {
           try {
-            view.goTo({
-              target,
-              heading: view.camera.heading + 0.2,
-            }, { animate: false });
+            view.goTo(
+              {
+                target,
+                heading: view.camera.heading + 0.2,
+              },
+              { animate: false },
+            );
           } catch (err) {
             // do nothing
           }
@@ -157,12 +180,15 @@ class SceneView extends Component {
   getGeometry(layerId, id) {
     if (!this.state.view || !this.state.view.layerViews) return null;
 
-    const layerView = this.state.view.layerViews.items.find(e => e.layer.id === layerId);
+    const layerView = this.state.view.layerViews.items.find(
+      e => e.layer.id === layerId,
+    );
     if (!layerView) return null;
     const { objectIdField } = layerView.layer;
 
-    const graphic = layerView.controller.graphics
-      .find(e => e.attributes.GlobalID === id || e.attributes[objectIdField] === id);
+    const graphic = layerView.controller.graphics.find(
+      e => e.attributes.GlobalID === id || e.attributes[objectIdField] === id,
+    );
     if (!graphic) return null;
 
     // TODO: this dirty hack needs improvement
@@ -170,7 +196,8 @@ class SceneView extends Component {
     return {
       ...graphic.geometry,
       rings: graphic.geometry.rings.map(ring =>
-        ring.map(point => [point[0], point[1], point[3]])),
+        ring.map(point => [point[0], point[1], point[3]]),
+      ),
     };
   }
 
@@ -183,12 +210,18 @@ class SceneView extends Component {
   }
 
   parseEnvironment(inputEnvironment) {
-    const { lighting: { utcDate, ...lighting }, ...environment } = inputEnvironment;
+    const {
+      lighting: { utcDate, ...lighting },
+      ...environment
+    } = inputEnvironment;
     environment.lighting = lighting;
 
     if (utcDate) {
-      const { hours, minutes, seconds } =
-        this.state.view.environment.lighting.positionTimezoneInfo;
+      const {
+        hours,
+        minutes,
+        seconds,
+      } = this.state.view.environment.lighting.positionTimezoneInfo;
 
       const newDate = new Date(utcDate);
       newDate.setUTCHours(utcDate.getUTCHours() - hours);
@@ -206,9 +239,14 @@ class SceneView extends Component {
       popup: this.props.popup,
     };
     if (this.props.goTo) viewSettings.camera = this.props.goTo;
-    const view = await loadEsriSceneView(this.componentRef, this.props.id, viewSettings);
+    const view = await loadEsriSceneView(
+      this.componentRef,
+      this.props.id,
+      viewSettings,
+    );
 
-    if (this.props.highlightOptions) view.highlightOptions = this.props.highlightOptions;
+    if (this.props.highlightOptions)
+      view.highlightOptions = this.props.highlightOptions;
     if (this.props.environment) view.environment = this.props.environment;
     if (this.props.padding) view.padding = this.props.padding;
 
@@ -221,27 +259,40 @@ class SceneView extends Component {
       <div
         id="sceneview"
         style={{ width: '100%', height: '100%' }}
-        ref={(ref) => { this.componentRef = ref; }}
+        ref={ref => {
+          this.componentRef = ref;
+        }}
       >
-        {this.state.view && this.props.children &&
-          React.Children.map(this.props.children,
-            child => child && React.cloneElement(child, {
-              ...this.state,
-            }))}
-        {this.state.view && this.props.onCameraChange &&
-          !(this.props.turntable && this.props.turntable.target) &&
-          <EventListeners.Camera
+        {this.state.view &&
+          this.props.children &&
+          React.Children.map(
+            this.props.children,
+            child =>
+              child &&
+              React.cloneElement(child, {
+                ...this.state,
+              }),
+          )}
+        {this.state.view &&
+          this.props.onCameraChange &&
+          !(this.props.turntable && this.props.turntable.target) && (
+            <EventListeners.Camera
+              view={this.state.view}
+              onCameraChange={this.props.onCameraChange}
+            />
+          )}
+        {this.state.view && this.props.onClick && (
+          <EventListeners.Click
             view={this.state.view}
-            onCameraChange={this.props.onCameraChange}
-          />}
-        {this.state.view && this.props.onClick && <EventListeners.Click
-          view={this.state.view}
-          onClick={this.props.onClick}
-        />}
-        {this.state.view && this.props.onMouseMove && <EventListeners.MouseMove
-          view={this.state.view}
-          onMouseMove={this.props.onMouseMove}
-        />}
+            onClick={this.props.onClick}
+          />
+        )}
+        {this.state.view && this.props.onMouseMove && (
+          <EventListeners.MouseMove
+            view={this.state.view}
+            onMouseMove={this.props.onMouseMove}
+          />
+        )}
       </div>
     );
   }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -73,8 +73,8 @@ class SceneView extends Component {
     this.loadSceneView();
   }
 
+  // eslint-disable-next-line
   async UNSAFE_componentWillUpdate(nextProps) {
-    // eslint-disable-line camelcase
     if (!this.state.view) return;
 
     if (this.props.environment !== nextProps.environment) {

--- a/src/legend/index.jsx
+++ b/src/legend/index.jsx
@@ -31,9 +31,12 @@ class Legend extends Component {
   async load(sceneViewId) {
     const [EsriLegend] = await esriLoader.loadModules(['esri/widgets/Legend']);
 
-    return new EsriLegend({
-      view: window.sceneViews[sceneViewId].view,
-    }, this.legendRef.current);
+    return new EsriLegend(
+      {
+        view: window.sceneViews[sceneViewId].view,
+      },
+      this.legendRef.current,
+    );
   }
 
   render() {

--- a/src/load.js
+++ b/src/load.js
@@ -18,7 +18,11 @@ import esriLoader from 'esri-loader';
 
 const uiPositions = ['top-left', 'top-right', 'bottom-right', 'bottom-left'];
 
-export const loadEsriSceneView = async (componentRef, id, sceneviewSettings) => {
+export const loadEsriSceneView = async (
+  componentRef,
+  id,
+  sceneviewSettings,
+) => {
   if (!window.sceneViews) {
     window.sceneViews = {};
   }

--- a/src/scene/__tests__/index.test.jsx
+++ b/src/scene/__tests__/index.test.jsx
@@ -38,17 +38,17 @@ jest.mock('esri-loader', () => {
   };
 });
 
-jest.mock('../layer', () => (view) => {
+jest.mock('../layer', () => view => {
   if (!view) return null;
   return <div id="layer" />;
 });
 
-jest.mock('../custom-basemap', () => (view) => {
+jest.mock('../custom-basemap', () => view => {
   if (!view) return null;
   return <div id="basemap" />;
 });
 
-jest.mock('../custom-elevation-layer', () => (view) => {
+jest.mock('../custom-elevation-layer', () => view => {
   if (!view) return null;
   return <div id="elevation-layer" />;
 });

--- a/src/scene/custom-basemap/index.jsx
+++ b/src/scene/custom-basemap/index.jsx
@@ -24,8 +24,10 @@ class CustomBasemap extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.portalItem !== prevProps.portalItem ||
-      this.props.basemap !== prevProps.basemap) {
+    if (
+      this.props.portalItem !== prevProps.portalItem ||
+      this.props.basemap !== prevProps.basemap
+    ) {
       this.loadBasemap();
     }
   }
@@ -37,7 +39,9 @@ class CustomBasemap extends Component {
   async loadBasemap() {
     if (this.props.portalItem) {
       const [Basemap] = await esriLoader.loadModules(['esri/Basemap']);
-      this.props.view.map.basemap = new Basemap({ portalItem: this.props.portalItem });
+      this.props.view.map.basemap = new Basemap({
+        portalItem: this.props.portalItem,
+      });
     } else {
       this.props.view.map.basemap = this.props.basemap;
     }

--- a/src/scene/custom-elevation-layer/index.jsx
+++ b/src/scene/custom-elevation-layer/index.jsx
@@ -29,7 +29,9 @@ class CustomElevationLayer extends Component {
   }
 
   async loadBasemap() {
-    const [ElevationLayer] = await esriLoader.loadModules(['esri/layers/ElevationLayer']);
+    const [ElevationLayer] = await esriLoader.loadModules([
+      'esri/layers/ElevationLayer',
+    ]);
 
     if (this.props.url) {
       this.setState({

--- a/src/scene/ground/index.jsx
+++ b/src/scene/ground/index.jsx
@@ -23,12 +23,12 @@ const groundSettingsProps = {
   surfaceColor: PropTypes.node,
 };
 
-const getSettings = (props) => {
+const getSettings = props => {
   const settings = {};
 
   Object.keys(groundSettingsProps)
     .filter(key => props[key] !== null && props[key] !== undefined)
-    .forEach(key => settings[key] = props[key]);
+    .forEach(key => (settings[key] = props[key]));
 
   return settings;
 };
@@ -38,7 +38,7 @@ const getUpdates = (props, nextProps) => {
 
   Object.keys(groundSettingsProps)
     .filter(key => props[key] !== nextProps[key])
-    .forEach(key => updates[key] = nextProps[key]);
+    .forEach(key => (updates[key] = nextProps[key]));
 
   return updates;
 };
@@ -48,13 +48,17 @@ class Ground extends Component {
     super(props);
 
     const settings = getSettings(this.props);
-    Object.keys(settings).forEach(key => this.props.view.map.ground[key] = settings[key]);
+    Object.keys(settings).forEach(
+      key => (this.props.view.map.ground[key] = settings[key]),
+    );
   }
 
   async componentDidUpdate(prevProps) {
     const updates = getUpdates(prevProps, this.props);
 
-    Object.keys(updates).forEach(key => this.props.view.map.ground[key] = updates[key]);
+    Object.keys(updates).forEach(
+      key => (this.props.view.map.ground[key] = updates[key]),
+    );
   }
 
   render() {

--- a/src/scene/index.jsx
+++ b/src/scene/index.jsx
@@ -36,13 +36,7 @@ class Scene extends Component {
   }
 
   async loadMap() {
-    const {
-      basemap,
-      ground,
-      initialViewProperties,
-      view,
-      onLoad,
-    } = this.props;
+    const { basemap, ground, initialViewProperties, view, onLoad } = this.props;
 
     const [WebScene] = await esriLoader.loadModules(['esri/WebScene']);
     const newMap = new WebScene({ basemap, ground, initialViewProperties });
@@ -59,7 +53,7 @@ class Scene extends Component {
   renderWrappedChildren(children) {
     if (!children) return null;
 
-    return React.Children.map(children, (child) => {
+    return React.Children.map(children, child => {
       // This is support for non-node elements (eg. pure text), they have no props
       if (!child || !child.props) {
         return child;
@@ -77,16 +71,16 @@ class Scene extends Component {
   }
 
   render() {
-    const {
-      children,
-      view,
-    } = this.props;
+    const { children, view } = this.props;
 
-    return view && this.state.mapLoaded && (
-      <div id="scene">
-        {this.renderWrappedChildren(children)}
-        <SelectionLayer id="selection-shape" view={view} />
-      </div>
+    return (
+      view &&
+      this.state.mapLoaded && (
+        <div id="scene">
+          {this.renderWrappedChildren(children)}
+          <SelectionLayer id="selection-shape" view={view} />
+        </div>
+      )
     );
   }
 }
@@ -114,6 +108,14 @@ Scene.Webscene = Webscene;
 Scene.CustomBasemap = CustomBasemap;
 Scene.CustomElevationLayer = CustomElevationLayer;
 
-export { Scene, Layer, Webscene, Ground, Graphic, CustomBasemap, CustomElevationLayer };
+export {
+  Scene,
+  Layer,
+  Webscene,
+  Ground,
+  Graphic,
+  CustomBasemap,
+  CustomElevationLayer,
+};
 
 export default Scene;

--- a/src/scene/layer/__tests__/index.test.jsx
+++ b/src/scene/layer/__tests__/index.test.jsx
@@ -18,7 +18,6 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-import esriLoader from 'esri-loader';
 import { loadLayer } from '../load';
 
 import Layer from '../index';

--- a/src/scene/layer/__tests__/index.test.jsx
+++ b/src/scene/layer/__tests__/index.test.jsx
@@ -51,10 +51,12 @@ jest.mock('esri-loader', () => {
 const mockWhen = jest.fn(() => Promise.resolve());
 
 jest.mock('../load', () => ({
-  loadLayer: jest.fn(layerSettings => Promise.resolve({
-    ...layerSettings,
-    when: mockWhen,
-  })),
+  loadLayer: jest.fn(layerSettings =>
+    Promise.resolve({
+      ...layerSettings,
+      when: mockWhen,
+    }),
+  ),
 }));
 
 describe('components', () => {

--- a/src/scene/layer/graphic/index.jsx
+++ b/src/scene/layer/graphic/index.jsx
@@ -40,8 +40,9 @@ class Graphic extends Component {
 
   destroyGraphic() {
     if (this.objectId) {
-      const graphic = this.props.layer.graphics
-        .find(i => i.attributes[this.props.layer.objectIdField] === this.objectId);
+      const graphic = this.props.layer.graphics.find(
+        i => i.attributes[this.props.layer.objectIdField] === this.objectId,
+      );
       if (graphic) {
         this.props.layer.remove(graphic);
       }

--- a/src/scene/layer/index.jsx
+++ b/src/scene/layer/index.jsx
@@ -23,20 +23,28 @@ import layerSettingsProps from './layer-settings-props';
 import Graphic from './graphic';
 import { applyUpdates } from './update';
 
-const getLayerSettings = (props) => {
+const getLayerSettings = props => {
   const settings = {};
 
   Object.keys(layerSettingsProps)
     .filter(key => props.layerType !== 'point-cloud' || key !== 'opacity')
-    .filter(key => props.layerType !== 'web-tile' || (key !== 'legendEnabled' && key !== 'popupEnabled'))
+    .filter(
+      key =>
+        props.layerType !== 'web-tile' ||
+        (key !== 'legendEnabled' && key !== 'popupEnabled'),
+    )
     .filter(key => props[key] !== null && props[key] !== undefined)
-    .forEach(key => settings[key] = props[key]);
+    .forEach(key => (settings[key] = props[key]));
 
   return settings;
 };
 
-const arrayCompare = (a, b) => !Array.isArray(a) || !Array.isArray(b) ||
-  a.length !== b.length || !a.every(e => b.includes(e)) || !b.every(e => a.includes(e));
+const arrayCompare = (a, b) =>
+  !Array.isArray(a) ||
+  !Array.isArray(b) ||
+  a.length !== b.length ||
+  !a.every(e => b.includes(e)) ||
+  !b.every(e => a.includes(e));
 
 class Layer extends Component {
   constructor(props) {
@@ -55,7 +63,8 @@ class Layer extends Component {
 
   componentDidUpdate(prevProps) {
     if (!this.state.layer) return;
-    if (!Object.keys(prevProps).find(key => prevProps[key] !== this.props[key])) return;
+    if (!Object.keys(prevProps).find(key => prevProps[key] !== this.props[key]))
+      return;
 
     // refresh layer
     if (this.props.refresh !== prevProps.refresh) {
@@ -63,12 +72,20 @@ class Layer extends Component {
     }
 
     // highlights
-    if (this.props.highlight !== prevProps.highlight &&
-      arrayCompare(this.props.highlight, prevProps.highlight)) {
+    if (
+      this.props.highlight !== prevProps.highlight &&
+      arrayCompare(this.props.highlight, prevProps.highlight)
+    ) {
       this.updateHighlights();
     }
 
-    applyUpdates(prevProps, this.props, this.state.layer, this.state.layerView, this.esriUtils);
+    applyUpdates(
+      prevProps,
+      this.props,
+      this.state.layer,
+      this.state.layerView,
+      this.esriUtils,
+    );
   }
 
   componentWillUnmount() {
@@ -129,11 +146,13 @@ class Layer extends Component {
     await this.initEsriUtils();
 
     // Check if already exists (e.g., after hot reload)
-    const existingLayer = view.map.layers.items.find(l => l.id === layerSettings.id);
+    const existingLayer = view.map.layers.items.find(
+      l => l.id === layerSettings.id,
+    );
     let layer;
 
     try {
-      layer = existingLayer || await loadLayer(layerSettings);
+      layer = existingLayer || (await loadLayer(layerSettings));
     } catch (error) {
       // Don't try to continue and add layer to map if layer cannot be loaded (e.g. does not exist)
       return;
@@ -165,11 +184,17 @@ class Layer extends Component {
   }
 
   render() {
-    return this.state.layer && (
-      <div>
-        {this.props.children && React.Children.map(this.props.children, child =>
-          child && React.cloneElement(child, { layer: this.state.layer }))}
-      </div>
+    return (
+      this.state.layer && (
+        <div>
+          {this.props.children &&
+            React.Children.map(
+              this.props.children,
+              child =>
+                child && React.cloneElement(child, { layer: this.state.layer }),
+            )}
+        </div>
+      )
     );
   }
 }

--- a/src/scene/layer/load.js
+++ b/src/scene/layer/load.js
@@ -59,7 +59,7 @@ export const loadLayer = async ({
     const [EsriLayer] = await esriLoader.loadModules(['esri/layers/Layer']);
     const layer = await EsriLayer.fromArcGISServerUrl({ url });
     Object.keys(layerSettings).forEach(
-      key => layer[key] = layerSettings[key],
+      key => (layer[key] = layerSettings[key]),
     );
     return layer;
   }

--- a/src/scene/layer/update.js
+++ b/src/scene/layer/update.js
@@ -16,31 +16,35 @@
 import layerSettingsProps from './layer-settings-props';
 
 const getLayerUpdates = (prevProps, nextProps) => {
-  const changes = Object
-    .keys(layerSettingsProps)
-    .filter(key => prevProps.layerType !== 'web-tile' || (key !== 'legendEnabled' && key !== 'popupEnabled'))
+  const changes = Object.keys(layerSettingsProps)
+    .filter(
+      key =>
+        prevProps.layerType !== 'web-tile' ||
+        (key !== 'legendEnabled' && key !== 'popupEnabled'),
+    )
     .filter(key => !(prevProps[key] === undefined && nextProps[key] === null))
     .filter(key => prevProps[key] !== nextProps[key]);
 
   if (changes.length === 0) return {};
 
   const updates = {};
-  changes.forEach(key => updates[key] = nextProps[key]);
+  changes.forEach(key => (updates[key] = nextProps[key]));
 
   return updates;
 };
 
-export const applyUpdates = (prevProps, nextProps, layer, layerView, esriUtils) => {
+export const applyUpdates = (
+  prevProps,
+  nextProps,
+  layer,
+  layerView,
+  esriUtils,
+) => {
   const updatesDiff = getLayerUpdates(prevProps, nextProps);
 
-  const {
-    rendererJson,
-    source,
-    maskingGeometry,
-    ...updates
-  } = updatesDiff;
+  const { rendererJson, source, maskingGeometry, ...updates } = updatesDiff;
 
-  Object.keys(updates).forEach(key => layer[key] = updates[key]);
+  Object.keys(updates).forEach(key => (layer[key] = updates[key]));
 
   if (rendererJson !== undefined) {
     layer.renderer = esriUtils.rendererJsonUtils.fromJSON(rendererJson);
@@ -48,11 +52,13 @@ export const applyUpdates = (prevProps, nextProps, layer, layerView, esriUtils) 
 
   // update source graphics
   if (source) {
-    const newFeatures = nextProps.source
-      .filter(feature => !prevProps.source.includes(feature));
+    const newFeatures = nextProps.source.filter(
+      feature => !prevProps.source.includes(feature),
+    );
 
-    const oldFeatures = prevProps.source
-      .filter(feature => !nextProps.source.includes(feature));
+    const oldFeatures = prevProps.source.filter(
+      feature => !nextProps.source.includes(feature),
+    );
 
     if (!newFeatures.length && !oldFeatures.length) return;
 
@@ -84,11 +90,9 @@ export const applyUpdates = (prevProps, nextProps, layer, layerView, esriUtils) 
     }
 
     if (layer.type === 'integrated-mesh') {
-      layer.modifications = new esriUtils.SceneModifications(
-        [
-          new esriUtils.SceneModification({ geometry: polygon, type: 'clip' }),
-        ],
-      );
+      layer.modifications = new esriUtils.SceneModifications([
+        new esriUtils.SceneModification({ geometry: polygon, type: 'clip' }),
+      ]);
     }
   }
 };

--- a/src/scene/selection-layer/index.js
+++ b/src/scene/selection-layer/index.js
@@ -22,12 +22,16 @@ import selectionLayerSettings from './selection-layer-settings';
 
 class SelectionLayer extends Component {
   async componentDidMount() {
-    const [GraphicsLayer] = await esriLoader.loadModules(['esri/layers/GraphicsLayer']);
+    const [GraphicsLayer] = await esriLoader.loadModules([
+      'esri/layers/GraphicsLayer',
+    ]);
 
-    this.props.view.map.add(new GraphicsLayer({
-      id: this.props.id,
-      ...selectionLayerSettings,
-    }));
+    this.props.view.map.add(
+      new GraphicsLayer({
+        id: this.props.id,
+        ...selectionLayerSettings,
+      }),
+    );
   }
 
   render() {

--- a/src/scene/selection-layer/selection-layer-settings.js
+++ b/src/scene/selection-layer/selection-layer-settings.js
@@ -20,9 +20,7 @@ export const layerSettings = {
   visible: true,
   popupEnabled: false,
   source: [],
-  fields: [
-    { name: 'ObjectID', alias: 'ObjectID', type: 'oid' },
-  ],
+  fields: [{ name: 'ObjectID', alias: 'ObjectID', type: 'oid' }],
   objectIdField: 'ObjectID',
   geometryType: 'polygon',
   spatialReference: { wkid: 4326 },

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -51,10 +51,14 @@ class Webscene extends Component {
     if (prevProps.layerSettings !== this.props.layerSettings) {
       Object.keys(this.props.layerSettings).forEach(layerId => {
         const settings = this.props.layerSettings[layerId];
-        const layer = this.state.groupLayer.layers.items.find(l => l.id === layerId);
+        const layer = this.state.groupLayer.layers.items.find(
+          l => l.id === layerId,
+        );
         if (!layer) return;
 
-        Object.keys(settings).forEach(field => layer[field] = settings[field]);
+        Object.keys(settings).forEach(
+          field => (layer[field] = settings[field]),
+        );
       });
     }
   }
@@ -62,7 +66,11 @@ class Webscene extends Component {
   async loadWebscene() {
     if (!this.props.view || !this.props.view.map) return;
 
-    const [EsriWebScene, EsriGroupLayer, EsriLayer] = await esriLoader.loadModules([
+    const [
+      EsriWebScene,
+      EsriGroupLayer,
+      EsriLayer,
+    ] = await esriLoader.loadModules([
       'esri/WebScene',
       'esri/layers/GroupLayer',
       'esri/layers/Layer',
@@ -79,7 +87,9 @@ class Webscene extends Component {
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
       try {
-        const layer = await EsriLayer.fromPortalItem({ portalItem: this.props.portalItem });
+        const layer = await EsriLayer.fromPortalItem({
+          portalItem: this.props.portalItem,
+        });
         layers.push(layer);
       } catch (e) {
         // give up
@@ -98,7 +108,10 @@ class Webscene extends Component {
     this.update();
 
     if (this.props.onLoad) {
-      this.props.onLoad(this.state.groupLayer.layers.items, this.state.groupLayer.id);
+      this.props.onLoad(
+        this.state.groupLayer.layers.items,
+        this.state.groupLayer.id,
+      );
     }
   }
 

--- a/src/tools/area-measurement-tool/index.js
+++ b/src/tools/area-measurement-tool/index.js
@@ -41,7 +41,8 @@ class AreaMeasurementTool extends Component {
         this.measurementTool.viewModel &&
         this.measurementTool.viewModel.measurement &&
         this.measurementTool.viewModel.measurement.area &&
-        this.measurementTool.viewModel.measurement.area.state === 'available') {
+        this.measurementTool.viewModel.measurement.area.state === 'available'
+      ) {
         this.props.onChange(this.measurementTool.viewModel.measurement);
       }
     });

--- a/src/tools/distance-measurement-tool/index.js
+++ b/src/tools/distance-measurement-tool/index.js
@@ -36,9 +36,13 @@ class DistanceMeasurementTool extends Component {
     this.measurementTool.viewModel.newMeasurement();
 
     this.watcher = this.measurementTool.view.on('pointer-move', () => {
-      if (this.props.onChange && this.measurementTool.viewModel.measurement &&
+      if (
+        this.props.onChange &&
+        this.measurementTool.viewModel.measurement &&
         this.measurementTool.viewModel.measurement.directDistance &&
-        this.measurementTool.viewModel.measurement.directDistance.state === 'available') {
+        this.measurementTool.viewModel.measurement.directDistance.state ===
+          'available'
+      ) {
         this.props.onChange(this.measurementTool.viewModel.measurement);
       }
     });

--- a/src/tools/drawing-tool/index.js
+++ b/src/tools/drawing-tool/index.js
@@ -19,7 +19,9 @@ import PropTypes from 'prop-types';
 import esriLoader from 'esri-loader';
 // import unitOptions from '../../helpers/unit-options';
 
-const isValidGeometry = geometry => geometry && ['point', 'multipoint', 'polyline', 'polygon'].includes(geometry.type);
+const isValidGeometry = geometry =>
+  geometry &&
+  ['point', 'multipoint', 'polyline', 'polygon'].includes(geometry.type);
 
 class DrawingTool extends Component {
   async componentDidMount() {
@@ -49,7 +51,7 @@ class DrawingTool extends Component {
       this.createGraphic();
     }
 
-    this.onCreate = this.model.on('create', (event) => {
+    this.onCreate = this.model.on('create', event => {
       switch (event.state) {
         case 'start': {
           this.layerView.highlight(event.graphic);
@@ -72,7 +74,7 @@ class DrawingTool extends Component {
       }
     });
 
-    this.onUpdate = this.model.on('update', (event) => {
+    this.onUpdate = this.model.on('update', event => {
       if (event.state === 'active' || event.state === 'complete') {
         this.props.onDraw({
           geometry: event.graphics[0].geometry,
@@ -158,7 +160,14 @@ class DrawingTool extends Component {
 
 DrawingTool.propTypes = {
   onDraw: PropTypes.func,
-  geometryType: PropTypes.oneOf(['point', 'multipoint', 'polyline', 'polygon', 'rectangle', 'circle']),
+  geometryType: PropTypes.oneOf([
+    'point',
+    'multipoint',
+    'polyline',
+    'polygon',
+    'rectangle',
+    'circle',
+  ]),
   mode: PropTypes.oneOf(['hybrid', 'freehand', 'click']),
   view: PropTypes.object,
   geometry: PropTypes.object,

--- a/src/tools/feature-selection-tool/index.js
+++ b/src/tools/feature-selection-tool/index.js
@@ -25,8 +25,11 @@ let listener;
 
 class FeatureSelectionEventListener extends Component {
   async componentDidMount() {
-    listener = this.props.view.on('click', async (event) => {
-      const { results } = await this.props.view.hitTest({ x: event.x, y: event.y });
+    listener = this.props.view.on('click', async event => {
+      const { results } = await this.props.view.hitTest({
+        x: event.x,
+        y: event.y,
+      });
 
       if (!results) return;
 
@@ -47,9 +50,15 @@ class FeatureSelectionEventListener extends Component {
 
       const [{ geometry }] = graphics;
 
-      const [geometryEngine] = await esriLoader.loadModules(['esri/geometry/geometryEngine']);
+      const [geometryEngine] = await esriLoader.loadModules([
+        'esri/geometry/geometryEngine',
+      ]);
 
-      const intersectGeometry = geometryEngine.geodesicBuffer(geometry, -0.5, 'meters');
+      const intersectGeometry = geometryEngine.geodesicBuffer(
+        geometry,
+        -0.5,
+        'meters',
+      );
 
       const features = await handleSelectionQuery(
         this.props.view,

--- a/src/tools/lasso-selection-tool/get-graphic-from-lasso-points.js
+++ b/src/tools/lasso-selection-tool/get-graphic-from-lasso-points.js
@@ -16,51 +16,54 @@
 
 import getEsriGeometry from '../../helpers/get-esri-geometry';
 
-export const getGraphicFromLassoPoints = async (polyPoints) => {
+export const getGraphicFromLassoPoints = async polyPoints => {
   const points = polyPoints.map(point => point.mapPoint);
   const start = polyPoints[0].screenPoint;
   const end = polyPoints.slice(-1)[0].screenPoint;
   const distance2 =
-    ((start.x - end.x) * (start.x - end.x)) + ((start.y - end.y) * (start.y - end.y));
+    (start.x - end.x) * (start.x - end.x) +
+    (start.y - end.y) * (start.y - end.y);
 
-  return (distance2 > 50 ? {
-    attributes: {
-      ObjectID: 0,
-    },
-    geometry: await getEsriGeometry({
-      hasZ: false,
-      paths: [points.map(point => [point.x, point.y])],
-      spatialReference: { wkid: 3857 },
-    }),
-    spatialRelationship: 'esriSpatialRelIntersects',
-    symbol: {
-      type: 'simple-line',
-      color: [255, 192, 0, 1],
-      width: '3px',
-    },
-  } : {
-    attributes: {
-      ObjectID: 0,
-    },
-    geometry: await getEsriGeometry({
-      hasZ: false,
-      rings: [
-        ...points.map(point => [point.x, point.y]),
-        [points[0].x, points[0].y],
-      ],
-      spatialReference: { wkid: 3857 },
-    }),
-    spatialRelationship: 'esriSpatialRelIntersects',
-    symbol: {
-      type: 'simple-fill', // autocasts as new SimpleFillSymbol()
-      color: [0, 255, 255, 0.5],
-      outline: {
-        type: 'simple-line',
-        color: [0, 255, 255, 1],
-        width: '3px',
-      },
-    },
-  });
+  return distance2 > 50
+    ? {
+        attributes: {
+          ObjectID: 0,
+        },
+        geometry: await getEsriGeometry({
+          hasZ: false,
+          paths: [points.map(point => [point.x, point.y])],
+          spatialReference: { wkid: 3857 },
+        }),
+        spatialRelationship: 'esriSpatialRelIntersects',
+        symbol: {
+          type: 'simple-line',
+          color: [255, 192, 0, 1],
+          width: '3px',
+        },
+      }
+    : {
+        attributes: {
+          ObjectID: 0,
+        },
+        geometry: await getEsriGeometry({
+          hasZ: false,
+          rings: [
+            ...points.map(point => [point.x, point.y]),
+            [points[0].x, points[0].y],
+          ],
+          spatialReference: { wkid: 3857 },
+        }),
+        spatialRelationship: 'esriSpatialRelIntersects',
+        symbol: {
+          type: 'simple-fill', // autocasts as new SimpleFillSymbol()
+          color: [0, 255, 255, 0.5],
+          outline: {
+            type: 'simple-line',
+            color: [0, 255, 255, 1],
+            width: '3px',
+          },
+        },
+      };
 };
 
 export default getGraphicFromLassoPoints;

--- a/src/tools/lasso-selection-tool/index.js
+++ b/src/tools/lasso-selection-tool/index.js
@@ -30,7 +30,7 @@ class SelectionEventListener extends Component {
   }
 
   async componentDidMount() {
-    listener = this.props.view.on('drag', async (event) => {
+    listener = this.props.view.on('drag', async event => {
       event.stopPropagation();
 
       const screenPoint = { x: event.x, y: event.y };
@@ -78,12 +78,16 @@ class SelectionEventListener extends Component {
   }
 
   clearSelectionGraphic() {
-    const selectionShapeLayer = this.props.view.map.layers.items.find(l => l.id === 'selection-shape');
+    const selectionShapeLayer = this.props.view.map.layers.items.find(
+      l => l.id === 'selection-shape',
+    );
     selectionShapeLayer.graphics.removeAll();
   }
 
   updateSelectionGraphic(graphic) {
-    const selectionShapeLayer = this.props.view.map.layers.items.find(l => l.id === 'selection-shape');
+    const selectionShapeLayer = this.props.view.map.layers.items.find(
+      l => l.id === 'selection-shape',
+    );
     selectionShapeLayer.graphics.removeAll();
     selectionShapeLayer.graphics.add(graphic);
   }
@@ -96,7 +100,11 @@ class SelectionEventListener extends Component {
   }
 
   async doSelection(geometry, spatialRelationship, event) {
-    const features = await handleSelectionQuery(this.props.view, geometry, spatialRelationship);
+    const features = await handleSelectionQuery(
+      this.props.view,
+      geometry,
+      spatialRelationship,
+    );
 
     this.props.onSelect({
       features,

--- a/src/tools/line-selection-tool/index.js
+++ b/src/tools/line-selection-tool/index.js
@@ -32,7 +32,7 @@ class SelectionEventListener extends Component {
   }
 
   async componentDidMount() {
-    listener = this.props.view.on('drag', async (event) => {
+    listener = this.props.view.on('drag', async event => {
       event.stopPropagation();
 
       const screenPoint = { x: event.x, y: event.y };
@@ -81,12 +81,16 @@ class SelectionEventListener extends Component {
   }
 
   clearSelectionGraphic() {
-    const selectionShapeLayer = this.props.view.map.layers.items.find(l => l.id === 'selection-shape');
+    const selectionShapeLayer = this.props.view.map.layers.items.find(
+      l => l.id === 'selection-shape',
+    );
     selectionShapeLayer.graphics.removeAll();
   }
 
   updateSelectionGraphic(graphic) {
-    const selectionShapeLayer = this.props.view.map.layers.items.find(l => l.id === 'selection-shape');
+    const selectionShapeLayer = this.props.view.map.layers.items.find(
+      l => l.id === 'selection-shape',
+    );
     selectionShapeLayer.graphics.removeAll();
     selectionShapeLayer.graphics.add(graphic);
   }
@@ -101,7 +105,11 @@ class SelectionEventListener extends Component {
   }
 
   async doSelection(geometry, spatialRelationship, event) {
-    const features = await handleSelectionQuery(this.props.view, geometry, spatialRelationship);
+    const features = await handleSelectionQuery(
+      this.props.view,
+      geometry,
+      spatialRelationship,
+    );
 
     this.props.onSelect({
       features,

--- a/src/tools/rectangle-selection-tool/get-graphic-from-rectangle.js
+++ b/src/tools/rectangle-selection-tool/get-graphic-from-rectangle.js
@@ -15,7 +15,11 @@
  */
 import esriLoader from 'esri-loader';
 
-export const getGraphicFromRectangle = async (startPoint, endPoint, heading) => {
+export const getGraphicFromRectangle = async (
+  startPoint,
+  endPoint,
+  heading,
+) => {
   const [Polygon, Polyline, geometryEngine] = await esriLoader.loadModules([
     'esri/geometry/Polygon',
     'esri/geometry/Polyline',
@@ -25,7 +29,8 @@ export const getGraphicFromRectangle = async (startPoint, endPoint, heading) => 
   const startX = startPoint.screenPoint.x;
   const endX = endPoint.screenPoint.x;
 
-  const spatialRelationship = (startX > endX ? 'esriSpatialRelIntersects' : 'esriSpatialRelContains');
+  const spatialRelationship =
+    startX > endX ? 'esriSpatialRelIntersects' : 'esriSpatialRelContains';
 
   const line = new Polyline({
     paths: [
@@ -35,7 +40,11 @@ export const getGraphicFromRectangle = async (startPoint, endPoint, heading) => 
     spatialReference: { wkid: 3857 },
   });
 
-  const normalizedLine = geometryEngine.rotate(line, heading, startPoint.mapPoint);
+  const normalizedLine = geometryEngine.rotate(
+    line,
+    heading,
+    startPoint.mapPoint,
+  );
 
   const x1 = normalizedLine.paths[0][0][0];
   const y1 = normalizedLine.paths[0][0][1];
@@ -58,7 +67,11 @@ export const getGraphicFromRectangle = async (startPoint, endPoint, heading) => 
     spatialReference: { wkid: 3857 },
   });
 
-  const rectangle = geometryEngine.rotate(normalizedRectangle, -heading, startPoint.mapPoint);
+  const rectangle = geometryEngine.rotate(
+    normalizedRectangle,
+    -heading,
+    startPoint.mapPoint,
+  );
 
   return {
     attributes: {
@@ -68,10 +81,16 @@ export const getGraphicFromRectangle = async (startPoint, endPoint, heading) => 
     spatialRelationship,
     symbol: {
       type: 'simple-fill',
-      color: spatialRelationship === 'esriSpatialRelContains' ? [0, 255, 255, 0.5] : [255, 192, 0, 0.5],
+      color:
+        spatialRelationship === 'esriSpatialRelContains'
+          ? [0, 255, 255, 0.5]
+          : [255, 192, 0, 0.5],
       outline: {
         type: 'simple-line',
-        color: spatialRelationship === 'esriSpatialRelContains' ? [0, 255, 255, 1] : [255, 192, 0, 1],
+        color:
+          spatialRelationship === 'esriSpatialRelContains'
+            ? [0, 255, 255, 1]
+            : [255, 192, 0, 1],
         width: '3px',
       },
     },

--- a/src/tools/rectangle-selection-tool/index.js
+++ b/src/tools/rectangle-selection-tool/index.js
@@ -33,7 +33,7 @@ class SelectionEventListener extends Component {
   }
 
   async componentDidMount() {
-    listener = this.props.view.on('drag', async (event) => {
+    listener = this.props.view.on('drag', async event => {
       event.stopPropagation();
 
       const screenPoint = { x: event.x, y: event.y };
@@ -85,16 +85,24 @@ class SelectionEventListener extends Component {
   }
 
   getGraphic() {
-    return getGraphicFromRectangle(this.state.startPoint, this.state.endPoint, this.state.heading);
+    return getGraphicFromRectangle(
+      this.state.startPoint,
+      this.state.endPoint,
+      this.state.heading,
+    );
   }
 
   clearSelectionGraphic() {
-    const selectionShapeLayer = this.props.view.map.layers.items.find(l => l.id === 'selection-shape');
+    const selectionShapeLayer = this.props.view.map.layers.items.find(
+      l => l.id === 'selection-shape',
+    );
     selectionShapeLayer.graphics.removeAll();
   }
 
   updateSelectionGraphic(graphic) {
-    const selectionShapeLayer = this.props.view.map.layers.items.find(l => l.id === 'selection-shape');
+    const selectionShapeLayer = this.props.view.map.layers.items.find(
+      l => l.id === 'selection-shape',
+    );
     selectionShapeLayer.graphics.removeAll();
     selectionShapeLayer.graphics.add(graphic);
   }
@@ -109,7 +117,11 @@ class SelectionEventListener extends Component {
   }
 
   async doSelection(geometry, spatialRelationship, event) {
-    const features = await handleSelectionQuery(this.props.view, geometry, spatialRelationship);
+    const features = await handleSelectionQuery(
+      this.props.view,
+      geometry,
+      spatialRelationship,
+    );
 
     this.props.onSelect({
       features,

--- a/src/tools/slice-tool/index.js
+++ b/src/tools/slice-tool/index.js
@@ -22,9 +22,7 @@ class SliceTool extends Component {
   async componentDidMount() {
     this.componentIsMounted = true;
 
-    const [Slice] = await esriLoader.loadModules([
-      'esri/widgets/Slice',
-    ]);
+    const [Slice] = await esriLoader.loadModules(['esri/widgets/Slice']);
     if (!this.componentIsMounted) return;
 
     this.sliceTool = new Slice({

--- a/src/ui/compass/index.jsx
+++ b/src/ui/compass/index.jsx
@@ -39,7 +39,9 @@ class Compass extends Component {
   }
 
   async loadCompass() {
-    const [EsriCompass] = await esriLoader.loadModules(['esri/widgets/Compass']);
+    const [EsriCompass] = await esriLoader.loadModules([
+      'esri/widgets/Compass',
+    ]);
     this.setState({ compass: new EsriCompass({ view: this.props.view }) });
     this.props.view.ui.add(this.state.compass, this.props.position);
   }

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -35,7 +35,7 @@ class UI extends Component {
   }
 
   renderWrappedChildren(children) {
-    return React.Children.map(children, (child) => {
+    return React.Children.map(children, child => {
       // This is support for non-node elements (eg. pure text), they have no props
       if (!child || !child.props) {
         return child;
@@ -55,10 +55,12 @@ class UI extends Component {
   }
 
   render() {
-    return this.props.view && (
-      <React.Fragment>
-        {this.renderWrappedChildren(this.props.children)}
-      </React.Fragment>
+    return (
+      this.props.view && (
+        <React.Fragment>
+          {this.renderWrappedChildren(this.props.children)}
+        </React.Fragment>
+      )
     );
   }
 }

--- a/src/ui/navigation-toggle/index.jsx
+++ b/src/ui/navigation-toggle/index.jsx
@@ -37,8 +37,12 @@ class NavigationToggle extends Component {
   }
 
   async loadNavigationToggle() {
-    const [EsriNavigationToggle] = await esriLoader.loadModules(['esri/widgets/NavigationToggle']);
-    this.setState({ navigationToggle: new EsriNavigationToggle({ view: this.props.view }) });
+    const [EsriNavigationToggle] = await esriLoader.loadModules([
+      'esri/widgets/NavigationToggle',
+    ]);
+    this.setState({
+      navigationToggle: new EsriNavigationToggle({ view: this.props.view }),
+    });
     this.props.view.ui.add(this.state.navigationToggle, this.props.position);
   }
 

--- a/src/ui/zoom/index.jsx
+++ b/src/ui/zoom/index.jsx
@@ -55,7 +55,12 @@ class Zoom extends Component {
 }
 
 Zoom.propTypes = {
-  position: PropTypes.oneOf(['top-left', 'top-right', 'bottom-right', 'bottom-left']),
+  position: PropTypes.oneOf([
+    'top-left',
+    'top-right',
+    'bottom-right',
+    'bottom-left',
+  ]),
   layout: PropTypes.oneOf(['horizontal', 'vertical']),
   view: PropTypes.object,
 };


### PR DESCRIPTION
Few enhancements so that the developer experience working with this repo as well as code quality can be improved 🤗 

- Did a facelift for `react-sceneview` by adding prettier (+formatting/fixing* all existing files --> resulted in a lot of file changes)
- Added `eslint-config-prettier` to make sure that prettier & eslint are working nicely together & not conflicting with each other
- Added a pre-commit hook so that files are automatically formatted when staged & files that do not pass the linter are not allowed to be committed (shows an error message & saves errors to `.eslintcache`)

I used the pre-commit hook `lint-staged` as recommended by prettier: https://prettier.io/docs/en/precommit.html

Changes have already been discussed with @sandromartis.

*fixes included one unused var in a test file & an eslint inline disable that had to move to a new line 😁 