### PR TITLE
Handle ground layers in webscene component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -100,6 +100,7 @@ class Webscene extends Component {
           l => l.title !== 'Terrain 3D' && l.visible,
         );
         // assign only fist ground layer to avoid out-of-sync layer settings, e.g. visibility
+        // as there is no way (yet) to add a group layer to the ground of a SceneView
         groundLayer = filteredGroundLayers[0];
       }
     } catch (err) {

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -96,7 +96,7 @@ class Webscene extends Component {
       layers.push(...webscene.layers.items);
 
       if (this.props.ground) {
-        // filter out the defailt 3D terrain
+        // filter out the default 3D terrain
         const filteredGroundLayers = webscene.ground.layers.items.filter(
           l => l.title !== 'Terrain 3D',
         );

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -59,10 +59,9 @@ class Webscene extends Component {
       Object.keys(this.props.layerSettings).forEach(layerId => {
         const settings = this.props.layerSettings[layerId];
         const layer =
-          this.state.groupLayer.layers.items.find(l => l.id === layerId) ||
-          (this.state.groundLayer.id === layerId
+          this.state.groundLayer.id === layerId
             ? this.state.groundLayer
-            : undefined);
+            : this.state.groupLayer.layers.items.find(l => l.id === layerId);
         if (!layer) return;
 
         Object.keys(settings).forEach(
@@ -100,7 +99,7 @@ class Webscene extends Component {
         const filteredGroundLayers = webscene.ground.layers.items.filter(
           l => l.title !== 'Terrain 3D' && l.visible,
         );
-        // assign the first ground layer
+        // assign only fist ground layer to avoid out-of-sync layer settings, e.g. visibility
         groundLayer = filteredGroundLayers[0];
       }
     } catch (err) {

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -60,9 +60,9 @@ class Webscene extends Component {
     if (prevProps.layerSettings !== this.props.layerSettings) {
       Object.keys(this.props.layerSettings).forEach(layerId => {
         const settings = this.props.layerSettings[layerId];
-        const layer = this.state.groupLayer.layers.items.find(
-          l => l.id === layerId,
-        );
+        const layer =
+          this.state.groupLayer.layers.items.find(l => l.id === layerId) ||
+          this.state.groundLayers.find(l => l.id === layerId);
         if (!layer) return;
 
         Object.keys(settings).forEach(

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -58,10 +58,10 @@ class Webscene extends Component {
     if (prevProps.layerSettings !== this.props.layerSettings) {
       Object.keys(this.props.layerSettings).forEach(layerId => {
         const settings = this.props.layerSettings[layerId];
-        const layer =
-          this.state.groundLayer.id === layerId
-            ? this.state.groundLayer
-            : this.state.groupLayer.layers.items.find(l => l.id === layerId);
+        const layer = [
+          ...this.state.groupLayer.layers.items,
+          this.state.groundLayer,
+        ].find(l => l.id === layerId);
         if (!layer) return;
 
         Object.keys(settings).forEach(

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -23,6 +23,7 @@ class Webscene extends Component {
     super(props);
     this.state = {
       groupLayer: null,
+      groundLayers: null,
     };
   }
 
@@ -39,6 +40,7 @@ class Webscene extends Component {
     if (!this.props.view || !this.props.view.map) return;
     this.componentIsMounted = false;
     this.props.view.map.remove(this.state.groupLayer);
+    this.props.view.map.ground.layers.removeMany(this.state.groundLayers);
   }
 
   update(prevProps = {}) {
@@ -106,6 +108,7 @@ class Webscene extends Component {
     this.state.groupLayer.addMany(layers);
     this.props.view.map.layers.add(groupLayer);
 
+    this.setState({ groundLayers });
     this.props.view.map.ground.layers.addMany(groundLayers);
 
     await this.props.view.whenLayerView(groupLayer);

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -70,12 +70,14 @@ class Webscene extends Component {
     if (!this.componentIsMounted) return;
 
     const layers = [];
+    const groundLayers = [];
 
     try {
       const webscene = new EsriWebScene({ portalItem: this.props.portalItem });
       await webscene.load();
 
       layers.push(...webscene.layers.items);
+      groundLayers.push(...webscene.ground.layers.items);
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
       try {
@@ -93,6 +95,8 @@ class Webscene extends Component {
     this.setState({ groupLayer });
     this.state.groupLayer.addMany(layers);
     this.props.view.map.layers.add(groupLayer);
+
+    this.props.view.map.ground.layers.addMany(groundLayers);
 
     await this.props.view.whenLayerView(groupLayer);
     this.update();

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -118,6 +118,7 @@ class Webscene extends Component {
       this.props.onLoad(
         this.state.groupLayer.layers.items,
         this.state.groupLayer.id,
+        this.state.groundLayers.layers.items,
       );
     }
   }

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -94,7 +94,14 @@ class Webscene extends Component {
       await webscene.load();
 
       layers.push(...webscene.layers.items);
-      groundLayers.push(...webscene.ground.layers.items);
+
+      if (this.props.ground) {
+        // filter out the defailt 3D terrain
+        const filteredGroundLayers = webscene.ground.layers.items.filter(
+          l => l.title !== 'Terrain 3D',
+        );
+        groundLayers.push(...filteredGroundLayers);
+      }
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
       try {
@@ -141,6 +148,7 @@ Webscene.propTypes = {
   visible: PropTypes.bool,
   onLoad: PropTypes.func,
   layerSettings: PropTypes.object,
+  ground: PropTypes.bool,
 };
 
 Webscene.defaultProps = {
@@ -148,6 +156,7 @@ Webscene.defaultProps = {
   visible: true,
   onLoad: null,
   layerSettings: {},
+  ground: true,
 };
 
 export default Webscene;

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -44,10 +44,17 @@ class Webscene extends Component {
   }
 
   update(prevProps = {}) {
-    if (!this.props.view || !this.state.groupLayer) return;
+    if (!this.props.view) return;
 
     if (prevProps.visible !== this.props.visible) {
-      this.state.groupLayer.visible = this.props.visible;
+      if (this.state.groupLayer) {
+        this.state.groupLayer.visible = this.props.visible;
+      }
+      if (this.state.groundLayers) {
+        this.state.groundLayers.forEach(
+          layer => (layer.visible = this.props.visible),
+        );
+      }
     }
 
     if (prevProps.layerSettings !== this.props.layerSettings) {
@@ -118,7 +125,7 @@ class Webscene extends Component {
       this.props.onLoad(
         this.state.groupLayer.layers.items,
         this.state.groupLayer.id,
-        this.state.groundLayers.layers.items,
+        this.state.groundLayers,
       );
     }
   }


### PR DESCRIPTION
This PR adds the ability to add and toggle layer settings (e.g. visible) of `groundLayers` from a web scene to the scene view. The property `ground` was added to the webscene component for this. The default is `true` but this can be discussed.

Before:
![image](https://user-images.githubusercontent.com/27951811/104914883-1193e580-5990-11eb-8cdd-be49b270ab2a.png)

After:
![image](https://user-images.githubusercontent.com/27951811/104914917-1d7fa780-5990-11eb-9a7f-85fbab52fdab.png)
