### PR TITLE
Handle ground layers: Better null handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -40,7 +40,10 @@ class Webscene extends Component {
     if (!this.props.view || !this.props.view.map) return;
     this.componentIsMounted = false;
     this.props.view.map.remove(this.state.groupLayer);
-    this.props.view.map.ground.layers.remove(this.state.groundLayer);
+
+    if (this.state.groundLayer) {
+      this.props.view.map.ground.layers.remove(this.state.groundLayer);
+    }
   }
 
   update(prevProps = {}) {
@@ -58,10 +61,10 @@ class Webscene extends Component {
     if (prevProps.layerSettings !== this.props.layerSettings) {
       Object.keys(this.props.layerSettings).forEach(layerId => {
         const settings = this.props.layerSettings[layerId];
-        const layer = [
-          ...this.state.groupLayer.layers.items,
-          this.state.groundLayer,
-        ].find(l => l.id === layerId);
+        const layer =
+          this.state.groundLayer && this.state.groundLayer.id === layerId
+            ? this.state.groundLayer
+            : this.state.groupLayer.layers.items.find(l => l.id === layerId);
         if (!layer) return;
 
         Object.keys(settings).forEach(
@@ -101,7 +104,7 @@ class Webscene extends Component {
         );
         // assign only fist ground layer to avoid out-of-sync layer settings, e.g. visibility
         // as there is no way (yet) to add a group layer to the ground of a SceneView
-        groundLayer = filteredGroundLayers[0];
+        groundLayer = filteredGroundLayers ? filteredGroundLayers[0] : null;
       }
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.
@@ -123,8 +126,10 @@ class Webscene extends Component {
     this.state.groupLayer.addMany(layers);
     this.props.view.map.layers.add(groupLayer);
 
-    this.setState({ groundLayer });
-    this.props.view.map.ground.layers.add(groundLayer);
+    if (groundLayer) {
+      this.setState({ groundLayer });
+      this.props.view.map.ground.layers.add(groundLayer);
+    }
 
     await this.props.view.whenLayerView(groupLayer);
     this.update();

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -102,9 +102,10 @@ class Webscene extends Component {
         const filteredGroundLayers = webscene.ground.layers.items.filter(
           l => l.id !== 'globalElevation' && l.visible,
         );
-        // assign only fist ground layer to avoid out-of-sync layer settings, e.g. visibility
-        // as there is no way (yet) to add a group layer to the ground of a SceneView
-        groundLayer = filteredGroundLayers[0];
+        // assign only first ground layer from layer list (reverse order) in SceneViewer
+        // to avoid out-of-sync layer settings, e.g. visibility as there is no way (yet)
+        // to add a group layer to the ground of a SceneView
+        groundLayer = filteredGroundLayers.reverse()[0];
       }
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -100,7 +100,7 @@ class Webscene extends Component {
       if (this.props.ground) {
         // filter out the default 3D terrain and ground layers that are not visible
         const filteredGroundLayers = webscene.ground.layers.items.filter(
-          l => l.title !== 'Terrain 3D' && l.visible,
+          l => l.id !== 'globalElevation' && l.visible,
         );
         // assign only fist ground layer to avoid out-of-sync layer settings, e.g. visibility
         // as there is no way (yet) to add a group layer to the ground of a SceneView

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -105,7 +105,7 @@ class Webscene extends Component {
         // assign only first ground layer from layer list (reverse order) in SceneViewer
         // to avoid out-of-sync layer settings, e.g. visibility as there is no way (yet)
         // to add a group layer to the ground of a SceneView
-        groundLayer = filteredGroundLayers.reverse()[0];
+        groundLayer = filteredGroundLayers.slice(-1)[0];
       }
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -104,9 +104,7 @@ class Webscene extends Component {
         );
         // assign only fist ground layer to avoid out-of-sync layer settings, e.g. visibility
         // as there is no way (yet) to add a group layer to the ground of a SceneView
-        groundLayer = filteredGroundLayers.length
-          ? filteredGroundLayers[0]
-          : null;
+        groundLayer = filteredGroundLayers[0];
       }
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.

--- a/src/scene/webscene/index.jsx
+++ b/src/scene/webscene/index.jsx
@@ -61,10 +61,10 @@ class Webscene extends Component {
     if (prevProps.layerSettings !== this.props.layerSettings) {
       Object.keys(this.props.layerSettings).forEach(layerId => {
         const settings = this.props.layerSettings[layerId];
-        const layer =
-          this.state.groundLayer && this.state.groundLayer.id === layerId
-            ? this.state.groundLayer
-            : this.state.groupLayer.layers.items.find(l => l.id === layerId);
+        const layer = [
+          ...this.state.groupLayer.layers.items,
+          this.state.groundLayer,
+        ].find(l => l && l.id === layerId);
         if (!layer) return;
 
         Object.keys(settings).forEach(
@@ -104,7 +104,9 @@ class Webscene extends Component {
         );
         // assign only fist ground layer to avoid out-of-sync layer settings, e.g. visibility
         // as there is no way (yet) to add a group layer to the ground of a SceneView
-        groundLayer = filteredGroundLayers ? filteredGroundLayers[0] : null;
+        groundLayer = filteredGroundLayers.length
+          ? filteredGroundLayers[0]
+          : null;
       }
     } catch (err) {
       // if portal item turns out to be a layer instead of a webscene, don't care and add it anyway.


### PR DESCRIPTION
Functional testing of https://devtopia.esri.com/WebGIS/urban-designer/pull/3356 in urban-designer has revealed some shortcomings of previous PR #82. The errors reported come from `this.props.view.map.ground.layers.add(groundLayer)` for the case of `groundLayer` being undefined or null (e.g. in case of `ground` is not requested or there are no ground layers in the webscene).

The added null handling should prevent console errors & crashes of the SceneView.
