### PR TITLE
Replaced deprecated functions by current js-api-4.19 equivalent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/tools/area-measurement-tool/index.js
+++ b/src/tools/area-measurement-tool/index.js
@@ -33,7 +33,7 @@ class AreaMeasurementTool extends Component {
       unit: this.props.unit,
     });
 
-    this.measurementTool.viewModel.newMeasurement();
+    await this.measurementTool.viewModel.start();
 
     this.watcher = this.measurementTool.view.on('click', () => {
       if (

--- a/src/tools/distance-measurement-tool/index.js
+++ b/src/tools/distance-measurement-tool/index.js
@@ -33,7 +33,7 @@ class DistanceMeasurementTool extends Component {
       unit: this.props.unit,
     });
 
-    this.measurementTool.viewModel.newMeasurement();
+    await this.measurementTool.viewModel.start();
 
     this.watcher = this.measurementTool.view.on('pointer-move', () => {
       if (

--- a/src/tools/slice-tool/index.js
+++ b/src/tools/slice-tool/index.js
@@ -29,7 +29,7 @@ class SliceTool extends Component {
       view: this.props.view,
     });
 
-    this.sliceTool.viewModel.newSlice();
+    await this.sliceTool.viewModel.start();
 
     this.sliceTool.viewModel.excludeGroundSurface = this.props.excludeGround;
   }


### PR DESCRIPTION
Related JIRA issue: https://zrh-web.esri.com/jira/browse/UP-4313

The `newMeasurement` functions of each analysis tools where replaced by an equivalent `start` function. Just replacing these fixed the thrown exception.