### PR TITLE
Enable snapping for JS API 4.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/tools/drawing-tool/index.js
+++ b/src/tools/drawing-tool/index.js
@@ -25,7 +25,7 @@ const isValidGeometry = geometry =>
 
 class DrawingTool extends Component {
   async componentDidMount() {
-    const { view, geometry } = this.props;
+    const { view, geometry, snappingLayerIds } = this.props;
 
     const [SketchViewModel, GraphicsLayer] = await esriLoader.loadModules([
       'esri/widgets/Sketch/SketchViewModel',
@@ -44,6 +44,15 @@ class DrawingTool extends Component {
     });
 
     this.model.snappingOptions.enabled = true;
+
+    if (snappingLayerIds) {
+      this.model.snappingOptions.featureEnabled = true;
+      this.model.snappingOptions.featureSources = snappingLayerIds.map(
+        layerId => ({
+          layer: view.map.layers.find(layer => layer.id === layerId),
+        }),
+      );
+    }
 
     if (isValidGeometry(geometry)) {
       this.setGraphic(geometry);
@@ -171,6 +180,7 @@ DrawingTool.propTypes = {
   mode: PropTypes.oneOf(['hybrid', 'freehand', 'click']),
   view: PropTypes.object,
   geometry: PropTypes.object,
+  snappingLayerIds: PropTypes.array,
 };
 
 DrawingTool.defaultProps = {
@@ -179,6 +189,7 @@ DrawingTool.defaultProps = {
   view: null,
   geometry: null,
   onDraw: () => null,
+  snappingLayerIds: null,
 };
 
 export default DrawingTool;

--- a/src/tools/drawing-tool/index.js
+++ b/src/tools/drawing-tool/index.js
@@ -43,7 +43,7 @@ class DrawingTool extends Component {
       view,
     });
 
-    this.model.snappingOptions.selfEnabled = true;
+    this.model.snappingOptions.enabled = true;
 
     if (isValidGeometry(geometry)) {
       this.setGraphic(geometry);


### PR DESCRIPTION
The syntax to enable snapping has changed with the new version of the JS API. Instead of `selfEnabled`, snapping is now turned on with the property `enabled`.

Currently, self snapping is not working anymore in Urban :) needs some fixing there as well after this is merged.

Additional, this PR adds functionality to enable snapping to other features with the `featureSources` property. The `DrawingTool` component takes a list of layer ids that are used as sources for snapping while drawing.