### PR TITLE
Implementation a react component encapsulating the js-api daylight widget

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,6 +34,7 @@ import AreaMeasurementTool from './tools/area-measurement-tool';
 import SliceTool from './tools/slice-tool';
 import LineOfSightTool from './tools/line-of-sight-tool';
 import ElevationProfileTool from './tools/elevation-profile-tool';
+import DaylightAnalysisTool from './tools/daylight-analysis-tool';
 
 import { loadEsriSceneView } from './load';
 
@@ -354,6 +355,7 @@ SceneView.AreaMeasurementTool = AreaMeasurementTool;
 SceneView.SliceTool = SliceTool;
 SceneView.LineOfSightTool = LineOfSightTool;
 SceneView.ElevationProfileTool = ElevationProfileTool;
+SceneView.DaylightAnalysisTool = DaylightAnalysisTool;
 
 export {
   SceneView,
@@ -373,6 +375,7 @@ export {
   SliceTool,
   LineOfSightTool,
   ElevationProfileTool,
+  DaylightAnalysisTool,
 };
 
 export default SceneView;

--- a/src/tools/daylight-analysis-tool/index.js
+++ b/src/tools/daylight-analysis-tool/index.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  *
  */
-
 import { Component } from 'react';
 import esriLoader from 'esri-loader';
 import PropTypes from 'prop-types';
@@ -26,6 +25,7 @@ class DaylightAnalysisTool extends Component {
     if (!this.componentIsMounted) return;
 
     this.daylightTool = new Daylight({
+      container: this.props.container,
       view: this.props.view,
       dateOrSeason: 'date',
       visibleElements: {
@@ -49,6 +49,7 @@ class DaylightAnalysisTool extends Component {
 }
 
 DaylightAnalysisTool.propTypes = {
+  container: PropTypes.string,
   view: PropTypes.object,
   onLoad: PropTypes.func,
   showPlayButtons: PropTypes.bool,
@@ -57,6 +58,7 @@ DaylightAnalysisTool.propTypes = {
 };
 
 DaylightAnalysisTool.defaultProps = {
+  container: '',
   view: null,
   onLoad: null,
   showPlayButtons: true,

--- a/src/tools/daylight-analysis-tool/index.js
+++ b/src/tools/daylight-analysis-tool/index.js
@@ -1,0 +1,67 @@
+/* Copyright 2021 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { Component } from 'react';
+import esriLoader from 'esri-loader';
+import PropTypes from 'prop-types';
+
+class DaylightAnalysisTool extends Component {
+  async componentDidMount() {
+    this.componentIsMounted = true;
+
+    const [Daylight] = await esriLoader.loadModules(['esri/widgets/Daylight']);
+    if (!this.componentIsMounted) return;
+
+    this.daylightTool = new Daylight({
+      view: this.props.view,
+      dateOrSeason: 'date',
+      visibleElements: {
+        playButtons: this.props.showPlayButtons,
+        datePicker: this.props.showDatePicker,
+        timezone: this.props.showTimezone,
+      },
+    });
+
+    if (this.props.onLoad) this.props.onLoad();
+  }
+
+  componentWillUnmount() {
+    this.componentIsMounted = false;
+    if (this.daylightTool) this.daylightTool.destroy();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+DaylightAnalysisTool.propTypes = {
+  view: PropTypes.object,
+  onLoad: PropTypes.func,
+  showPlayButtons: PropTypes.bool,
+  showDatePicker: PropTypes.bool,
+  showTimezone: PropTypes.bool,
+};
+
+DaylightAnalysisTool.defaultProps = {
+  view: null,
+  onLoad: null,
+  showPlayButtons: true,
+  showDatePicker: true,
+  showTimezone: false,
+};
+
+export default DaylightAnalysisTool;

--- a/src/tools/daylight-analysis-tool/index.js
+++ b/src/tools/daylight-analysis-tool/index.js
@@ -34,8 +34,6 @@ class DaylightAnalysisTool extends Component {
         timezone: this.props.showTimezone,
       },
     });
-
-    if (this.props.onLoad) this.props.onLoad();
   }
 
   componentWillUnmount() {
@@ -51,7 +49,6 @@ class DaylightAnalysisTool extends Component {
 DaylightAnalysisTool.propTypes = {
   container: PropTypes.string,
   view: PropTypes.object,
-  onLoad: PropTypes.func,
   showPlayButtons: PropTypes.bool,
   showDatePicker: PropTypes.bool,
   showTimezone: PropTypes.bool,
@@ -60,7 +57,6 @@ DaylightAnalysisTool.propTypes = {
 DaylightAnalysisTool.defaultProps = {
   container: '',
   view: null,
-  onLoad: null,
   showPlayButtons: true,
   showDatePicker: true,
   showTimezone: false,


### PR DESCRIPTION
JIRA Issue: https://zrh-web.esri.com/jira/browse/UP-4417

This is a simple encapsulation of the `esri/widgets/Daylight` js-api component (https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Daylight.html).

It exposes several of its properties, but not all of them. I can add the remaining ones if it makes sense.