### PR TITLE
Added the uniform chart scaling toggle and unit chooser as customizable element.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sceneview",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "react-sceneview",
   "main": "dist/react-sceneview.js",
   "module": "dist/react-sceneview.js",

--- a/src/tools/elevation-profile-tool/index.js
+++ b/src/tools/elevation-profile-tool/index.js
@@ -35,6 +35,8 @@ class ElevationProfileTool extends Component {
       visibleElements: {
         selectButton: this.props.displaySelectButton,
         settingsButton: this.props.displaySettingsButton,
+        unitSelector: this.props.displayUnitSelector,
+        uniformChartScalingToggle: this.props.displayUniformChartScalingToggle,
       },
     });
 
@@ -58,6 +60,8 @@ ElevationProfileTool.propTypes = {
   profiles: PropTypes.array,
   displaySelectButton: PropTypes.bool,
   displaySettingsButton: PropTypes.bool,
+  displayUnitSelector: PropTypes.bool,
+  displayUniformChartScalingToggle: PropTypes.bool,
 };
 
 ElevationProfileTool.defaultProps = {
@@ -73,6 +77,8 @@ ElevationProfileTool.defaultProps = {
   ],
   displaySelectButton: true,
   displaySettingsButton: true,
+  displayUnitSelector: true,
+  displayUniformChartScalingToggle: true,
 };
 
 export default ElevationProfileTool;


### PR DESCRIPTION
Js-api 4.20 added the uniform chart scaling toggle to the elevation profile widget. This PR exposes properties allowing to control if it will be displayed or not. Same for the unit chooser list picker.